### PR TITLE
feat: wire Integrated Math 3 curriculum loader

### DIFF
--- a/lib/getCurriculum.test.ts
+++ b/lib/getCurriculum.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getCurriculum,
+  parseCurriculumDocument,
+} from "./getCurriculum";
+import document from "../docs/data/integrated-math-3.course.json" assert { type: "json" };
+
+test("getCurriculum returns course metadata with units and lessons", () => {
+  const course = getCurriculum();
+  assert.equal(course.slug, "math3");
+  assert.ok(course.units.length > 0);
+  const firstUnit = course.units[0];
+  assert.ok(firstUnit.lessons.length > 0);
+});
+
+test("parseCurriculumDocument throws when course units are missing", () => {
+  const malformed = structuredClone(document);
+  // @ts-expect-error mutating for test coverage
+  delete malformed.course.units;
+
+  assert.throws(
+    () => {
+      parseCurriculumDocument(malformed);
+    },
+    /course\.units/
+  );
+});

--- a/lib/getCurriculum.ts
+++ b/lib/getCurriculum.ts
@@ -1,0 +1,292 @@
+import document from "../docs/data/integrated-math-3.course.json";
+
+export interface CurriculumAssessment {
+  id: string;
+  slug: string;
+  title: string | null;
+  descriptor: string | null;
+  kind: string | null;
+  url: string | null;
+  exerciseLength: number | null;
+  timeEstimate: {
+    lowerBound: number | null;
+    upperBound: number | null;
+  } | null;
+}
+
+export interface CurriculumItem {
+  id: string;
+  slug: string;
+  title: string | null;
+  description: string | null;
+  kind: string | null;
+  contentKind: string | null;
+  descriptor: string | null;
+  url: string | null;
+  isSkillCheck: boolean | null;
+  exerciseLength: number | null;
+  timeEstimate: {
+    lowerBound: number | null;
+    upperBound: number | null;
+  } | null;
+}
+
+export interface CurriculumLesson {
+  id: string;
+  slug: string;
+  title: string | null;
+  description: string | null;
+  relativeUrl: string | null;
+  url: string | null;
+  items: CurriculumItem[];
+}
+
+export interface CurriculumUnit {
+  id: string;
+  slug: string;
+  title: string | null;
+  description: string | null;
+  relativeUrl: string | null;
+  url: string | null;
+  lessons: CurriculumLesson[];
+  assessments: {
+    quizzes: CurriculumAssessment[];
+    unitTests: CurriculumAssessment[];
+    other: CurriculumAssessment[];
+  };
+}
+
+export interface CurriculumCourse {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  relativeUrl: string;
+  url: string;
+  masteryEnabled: boolean | null;
+  isListedForLearners: boolean | null;
+  courseChallenge: CurriculumAssessment | null;
+  masteryChallenge: CurriculumAssessment | null;
+  units: CurriculumUnit[];
+}
+
+export interface CurriculumSource {
+  query: string | null;
+  queryHash: number | null;
+  path: string | null;
+  countryCode: string | null;
+  fetchedAt: string | null;
+  contentCommitSha: string | null;
+}
+
+export interface CurriculumDocument {
+  source: CurriculumSource;
+  course: CurriculumCourse;
+}
+
+class CurriculumSchemaError extends Error {
+  constructor(message: string) {
+    super(`Invalid Integrated Math 3 course payload: ${message}`);
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+type TimeEstimate = {
+  lowerBound: number | null;
+  upperBound: number | null;
+} | null;
+
+function assertObject(value: unknown, path: string): asserts value is JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CurriculumSchemaError(`expected ${path} to be an object`);
+  }
+}
+
+function expectString(value: unknown, path: string): string {
+  if (typeof value !== "string") {
+    throw new CurriculumSchemaError(`expected ${path} to be a string`);
+  }
+  return value;
+}
+
+function expectNullableString(value: unknown, path: string): string | null {
+  if (value == null) return null;
+  return expectString(value, path);
+}
+
+function expectBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new CurriculumSchemaError(`expected ${path} to be a boolean`);
+  }
+  return value;
+}
+
+function expectNullableBoolean(value: unknown, path: string): boolean | null {
+  if (value == null) return null;
+  return expectBoolean(value, path);
+}
+
+function expectNumber(value: unknown, path: string): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new CurriculumSchemaError(`expected ${path} to be a number`);
+  }
+  return value;
+}
+
+function expectNullableNumber(value: unknown, path: string): number | null {
+  if (value == null) return null;
+  return expectNumber(value, path);
+}
+
+function expectArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new CurriculumSchemaError(`expected ${path} to be an array`);
+  }
+  return value;
+}
+
+function toTimeEstimate(value: unknown, path: string): TimeEstimate {
+  if (value == null) return null;
+  assertObject(value, path);
+  return {
+    lowerBound: expectNullableNumber(value.lowerBound, `${path}.lowerBound`),
+    upperBound: expectNullableNumber(value.upperBound, `${path}.upperBound`),
+  };
+}
+
+function normaliseAssessment(value: unknown, path: string): CurriculumAssessment {
+  assertObject(value, path);
+  return {
+    id: expectString(value.id, `${path}.id`),
+    slug: expectString(value.slug, `${path}.slug`),
+    title: expectNullableString(value.title, `${path}.title`),
+    descriptor: expectNullableString(value.descriptor, `${path}.descriptor`),
+    kind: expectNullableString(value.kind, `${path}.kind`),
+    url: expectNullableString(value.url, `${path}.url`),
+    exerciseLength: expectNullableNumber(value.exerciseLength, `${path}.exerciseLength`),
+    timeEstimate: toTimeEstimate(value.timeEstimate, `${path}.timeEstimate`),
+  };
+}
+
+function normaliseItem(value: unknown, path: string): CurriculumItem {
+  assertObject(value, path);
+  return {
+    id: expectString(value.id, `${path}.id`),
+    slug: expectString(value.slug, `${path}.slug`),
+    title: expectNullableString(value.title, `${path}.title`),
+    description: expectNullableString(value.description, `${path}.description`),
+    kind: expectNullableString(value.kind, `${path}.kind`),
+    contentKind: expectNullableString(value.contentKind, `${path}.contentKind`),
+    descriptor: expectNullableString(value.descriptor, `${path}.descriptor`),
+    url: expectNullableString(value.url, `${path}.url`),
+    isSkillCheck: expectNullableBoolean(value.isSkillCheck, `${path}.isSkillCheck`),
+    exerciseLength: expectNullableNumber(value.exerciseLength, `${path}.exerciseLength`),
+    timeEstimate: toTimeEstimate(value.timeEstimate, `${path}.timeEstimate`),
+  };
+}
+
+function normaliseLesson(value: unknown, path: string): CurriculumLesson {
+  assertObject(value, path);
+  const items = expectArray(value.items, `${path}.items`).map((item, index) =>
+    normaliseItem(item, `${path}.items[${index}]`),
+  );
+
+  return {
+    id: expectString(value.id, `${path}.id`),
+    slug: expectString(value.slug, `${path}.slug`),
+    title: expectNullableString(value.title, `${path}.title`),
+    description: expectNullableString(value.description, `${path}.description`),
+    relativeUrl: expectNullableString(value.relativeUrl, `${path}.relativeUrl`),
+    url: expectNullableString(value.url, `${path}.url`),
+    items,
+  };
+}
+
+function normaliseAssessments(value: unknown, path: string) {
+  assertObject(value, path);
+  const quizzes = expectArray(value.quizzes, `${path}.quizzes`).map((quiz, index) =>
+    normaliseAssessment(quiz, `${path}.quizzes[${index}]`),
+  );
+  const unitTests = expectArray(value.unitTests, `${path}.unitTests`).map((unitTest, index) =>
+    normaliseAssessment(unitTest, `${path}.unitTests[${index}]`),
+  );
+  const other = expectArray(value.other, `${path}.other`).map((node, index) =>
+    normaliseAssessment(node, `${path}.other[${index}]`),
+  );
+
+  return { quizzes, unitTests, other };
+}
+
+function normaliseUnit(value: unknown, path: string): CurriculumUnit {
+  assertObject(value, path);
+  const lessons = expectArray(value.lessons, `${path}.lessons`).map((lesson, index) =>
+    normaliseLesson(lesson, `${path}.lessons[${index}]`),
+  );
+
+  const assessments = normaliseAssessments(value.assessments, `${path}.assessments`);
+
+  return {
+    id: expectString(value.id, `${path}.id`),
+    slug: expectString(value.slug, `${path}.slug`),
+    title: expectNullableString(value.title, `${path}.title`),
+    description: expectNullableString(value.description, `${path}.description`),
+    relativeUrl: expectNullableString(value.relativeUrl, `${path}.relativeUrl`),
+    url: expectNullableString(value.url, `${path}.url`),
+    lessons,
+    assessments,
+  };
+}
+
+function normaliseSource(value: unknown, path: string): CurriculumSource {
+  assertObject(value, path);
+  return {
+    query: expectNullableString(value.query, `${path}.query`),
+    queryHash: expectNullableNumber(value.queryHash, `${path}.queryHash`),
+    path: expectNullableString(value.path, `${path}.path`),
+    countryCode: expectNullableString(value.countryCode, `${path}.countryCode`),
+    fetchedAt: expectNullableString(value.fetchedAt, `${path}.fetchedAt`),
+    contentCommitSha: expectNullableString(value.contentCommitSha, `${path}.contentCommitSha`),
+  };
+}
+
+function normaliseCourse(value: unknown, path: string): CurriculumCourse {
+  assertObject(value, path);
+  const units = expectArray(value.units, `${path}.units`).map((unit, index) =>
+    normaliseUnit(unit, `${path}.units[${index}]`),
+  );
+
+  return {
+    id: expectString(value.id, `${path}.id`),
+    slug: expectString(value.slug, `${path}.slug`),
+    title: expectString(value.title, `${path}.title`),
+    description: expectString(value.description, `${path}.description`),
+    relativeUrl: expectString(value.relativeUrl, `${path}.relativeUrl`),
+    url: expectString(value.url, `${path}.url`),
+    masteryEnabled: expectNullableBoolean(value.masteryEnabled, `${path}.masteryEnabled`),
+    isListedForLearners: expectNullableBoolean(value.isListedForLearners, `${path}.isListedForLearners`),
+    courseChallenge: value.courseChallenge == null
+      ? null
+      : normaliseAssessment(value.courseChallenge, `${path}.courseChallenge`),
+    masteryChallenge: value.masteryChallenge == null
+      ? null
+      : normaliseAssessment(value.masteryChallenge, `${path}.masteryChallenge`),
+    units,
+  };
+}
+
+export function parseCurriculumDocument(raw: unknown): CurriculumDocument {
+  assertObject(raw, "document");
+  const source = normaliseSource(raw.source, "document.source");
+  const course = normaliseCourse(raw.course, "document.course");
+  return { source, course };
+}
+
+let cachedCourse: CurriculumCourse | null = null;
+
+export function getCurriculum(): CurriculumCourse {
+  if (!cachedCourse) {
+    cachedCourse = parseCurriculumDocument(document).course;
+  }
+  return cachedCourse;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint --max-warnings=0 .",
-    "test": "node --test",
+    "test": "tsx --test",
     "sync:khan:math3": "node docs/scripts/sync-khan-course.mjs --path /math/math3 --slug integrated-math-3"
   },
   "dependencies": {
@@ -27,6 +27,7 @@
     "@types/react-dom": "^19.1.9",
     "eslint": "8.57.1",
     "eslint-config-next": "15.5.3",
+    "tsx": "^4.20.5",
     "typescript": "^5.6.3"
   },
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ devDependencies:
   eslint-config-next:
     specifier: 15.5.3
     version: 15.5.3(eslint@8.57.1)(typescript@5.9.2)
+  tsx:
+    specifier: ^4.20.5
+    version: 4.20.5
   typescript:
     specifier: ^5.6.3
     version: 5.9.2
@@ -76,6 +79,240 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
+    dev: true
+    optional: true
+
+  /@esbuild/aix-ppc64@0.25.10:
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.25.10:
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.25.10:
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.25.10:
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.10:
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.10:
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.10:
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.10:
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.10:
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.25.10:
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.10:
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.10:
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.10:
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.10:
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.10:
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.10:
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.25.10:
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.10:
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.10:
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.10:
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.25.10:
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.25.10:
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.10:
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.25.10:
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.10:
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.25.10:
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1348,6 +1585,40 @@ packages:
       is-symbol: 1.1.1
     dev: true
 
+  /esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+    dev: true
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -1739,6 +2010,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2952,6 +3231,17 @@ packages:
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  /tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
Closes #2.

## Summary
- add deterministic parser + cache for Integrated Math 3 course data
- surface schema errors early with targeted guards
- cover happy and failure cases with node:test + tsx runner

## Testing
- pnpm lint
- pnpm test
- pnpm build
