### PR TITLE
chore: establish linting baseline

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,35 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  ignorePatterns: ["out/**"],
+  overrides: [
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      parserOptions: {
+        project: ["./tsconfig.json"],
+        tsconfigRootDir: __dirname
+      }
+    },
+    {
+      files: ["**/*.d.ts"],
+      rules: {
+        "@typescript-eslint/triple-slash-reference": "off",
+      },
+    },
+    {
+      files: ["curriculum/**/*.mdx", "docs/**/*.mdx"],
+      extends: ["plugin:mdx/recommended"],
+      rules: {
+        // Placeholder for KA content linting rules to be added in Sprint S2
+        "mdx/no-unused-expressions": "off"
+      }
+    }
+  ]
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "root": true,
-  "extends": ["next/core-web-vitals"],
-  "ignorePatterns": ["out/**"]
-}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+.next
+out
+coverage
+node_modules
+
+# Generated files
+out

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,15 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 100,
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": "*.mdx",
+      "options": {
+        "printWidth": 80,
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,12 @@ This document orients automation, AI assistants, and future contributors to the 
 
 ## Repository Facts
 
-- Static Next.js application exported for GitHub Pages (`next export` → `./out`).
-- Content-first: objectives, lessons, practice generators, and flashcards live under `content/`.
-- Pedagogical focus on mastery learning, spaced retrieval, and multi-representational math instruction.
-- No runtime database or server access; all state is client-side (localStorage/IndexedDB).
+- **Functional static Next.js application** exported for GitHub Pages (`next export` → `./out`).
+- **Current enhancement phase**: Sprint S1 of 3-sprint brownfield enhancement initiative.
+- **Content-first architecture**: objectives, lessons, practice generators, and flashcards with Integrated Math 3 focus.
+- **Pedagogical foundation**: Mastery learning, spaced retrieval, and multi-representational math instruction.
+- **Client-side state**: All state managed via localStorage/IndexedDB with export/import capabilities.
+- **BMAD framework**: Structured development with specialized agents, tasks, and quality gates.
 
 ## Environment Expectations
 
@@ -21,78 +23,122 @@ This document orients automation, AI assistants, and future contributors to the 
 
 ## Content Structure
 
-- `content/objectives/`: YAML/JSON documents with IDs, titles, descriptions, prerequisites, standards, linked KA skills.
-- `content/lessons/<objectiveId>/<slug>.mdx`: Lesson narratives with embedded React components; front matter captures metadata.
-- `content/items/<objectiveId>/*.ts`: Deterministic generators exporting `generate(seed)` and `check(response)` plus hints, steps, misconception tags.
-- `content/cards/<objectiveId>.json`: Flashcard decks for spaced recall.
-- `docs/sprint/`: Sprint story breakdowns used by automation (`scripts/seed-issues.sh`) to create GitHub issues.
+- `curriculum/`: Course content and lesson materials (MDX format)
+  - `integrated-math-3.md`: Current course curriculum
+- `data/`: Static data including course information and progress tracking
+- `components/`: Interactive React components for math learning
+  - `MasteryIndicator.tsx`: Progress visualization
+  - `CurriculumOverview.tsx`: Course navigation
+- `lib/`: Utilities for content loading, progress tracking, and validation
+- `docs/`: Comprehensive project documentation
+  - `prd/`: Sharded Product Requirements Document
+  - `sprint/`: Sprint planning, roadmap, and current progress
+  - `qa/`: Quality assurance artifacts and gate reviews
+  - `architecture/`: Technical architecture and patterns
+- `app/`: Next.js app router pages and routing structure
 - `lib/`: Content loaders, RNG helpers, validation schemas, SRS utilities.
 - `components/`: Interactive widgets (FunctionGrapher, NumberLine, DragArrange, ScaffoldedSteps, etc.).
 
 ## GitHub Workflow (gh CLI)
 
-- Default branch: `main`, protected (PRs + approvals + lint/test checks required).
-- Branch naming: `<type>/<issue-number>-<kebab-title>` where `<type>` ∈ `feat|fix|chore|docs|refactor|test`.
-- Issues:
-  - Must include labels (e.g., `type:feature`, `area:frontend`, `priority:P2`) and a milestone (one sprint per milestone).
-  - Optional: add to project boards after creation.
-- Branch flow:
+- **Default branch**: `main`, protected with PRs + approvals + lint/test checks required.
+- **Branch naming**: `<type>/<issue-number>-<kebab-title>` where `<type>` ∈ `feat|fix|chore|docs|refactor|test`.
+- **Issue management**:
+  - Must include labels (e.g., `type:feature`, `area:frontend`, `priority:P2`) and sprint milestone.
+  - Optional: add to project boards for enhanced tracking.
+- **Development flow**:
   1. Create issue via `gh issue create` (include milestone, labels, assignee).
   2. Create branch from issue number.
-  3. Implement feature; keep commits Conventional.
-  4. Run `pnpm lint && pnpm test`.
+  3. Implement feature following BMAD story structure.
+  4. Run `pnpm lint && pnpm test` for validation.
   5. Push branch, open PR with `gh pr create --fill --label ... --milestone ...`.
   6. Request review, enable auto-squash merge (`gh pr merge --auto --squash`).
-  7. After merge: `git checkout main && git pull --ff-only`, delete branch locally and remote.
-- Sprint kickoff automation:
-  - Author stories in `docs/sprint/SX.md`.
-  - Dry-run issue seeding, then apply with `scripts/seed-issues.sh`.
+  7. After merge: `git checkout main && git pull --ff-only`, cleanup branches.
+- **Sprint management**:
+  - Stories authored in `docs/sprint/SX.md` with BMAD framework.
+  - Issue seeding via `scripts/seed-issues.sh` with sprint context.
   - Environment variables: `SPRINT_MILESTONE`, `ASSIGNEE`, `EXTRA_LABELS`.
+- **Quality gates**: QA reviews and automated checks ensure code quality and feature completeness.
 
 ## Testing & Quality Gates
 
-- TDD mandated: write failing tests first, then implement, then refactor.
-- Unit tests colocated with code (`*.test.ts` / `*.spec.ts`).
-- Integration tests cover lesson rendering, data wiring, and static generation.
-- Optional Playwright E2E for core flows (warmups, lesson, spaced practice).
-- Coverage goal: ≥80% on core modules (flexible during MVP).
-- Deterministic RNG: all item generators must accept `seed` and use shared helpers (e.g., `mulberry32`).
-- Accessibility checks (axe) should run on key lesson templates.
+- **TDD approach**: Write failing tests first, then implement, then refactor.
+- **Test structure**: Unit tests colocated with code (`*.test.ts` / `*.spec.ts`).
+- **Integration coverage**: Lesson rendering, data wiring, and static generation.
+- **E2E testing**: Optional Playwright for core flows (warmups, lessons, spaced practice).
+- **Coverage targets**: ≥80% on core modules (flexible during enhancement sprints).
+- **Deterministic generators**: All item generators accept `seed` parameter using shared helpers.
+- **Accessibility**: Automated checks (axe) on key lesson templates and components.
+- **BMAD quality gates**: Structured QA process with risk assessment and traceability.
+- **Static export validation**: Ensure all changes maintain GitHub Pages compatibility.
 
 ## Deployment & Automation
 
-- CI pipeline:
-  - Install dependencies.
-  - Run lint/tests.
-  - Run `pnpm build` and `next export`.
-  - Publish `/out` to `gh-pages`.
-- Required status checks: lint, unit tests, integration tests.
-- CODEOWNERS recommended for content vs. infra paths.
-- Auto-label GitHub Action (optional) to apply `area:*` labels based on file globs.
+- **CI/CD pipeline**:
+  - Install dependencies with pnpm.
+  - Run lint and test suites.
+  - Execute `pnpm build` and `next export`.
+  - Publish `/out` to `gh-pages` branch.
+- **Required checks**: Lint, unit tests, integration tests must pass.
+- **Khan Academy sync**: Automated course data updates (see `docs/automation.md`).
+- **CODEOWNERS**: Recommended for content vs. infrastructure path separation.
+- **Auto-labeling**: GitHub Actions apply `area:*` labels based on file patterns.
+- **Sprint deployments**: Regular releases aligned with sprint milestones.
 
 ## Assistant Conduct
 
-- Honor repository-local conventions; never bypass lint/test commands when modifying code.
-  - For read-only contexts, provide patch snippets instead of direct edits.
-- Prefer `rg`, `sed`, `jq`, and other CLI tools for inspection; use `pnpm` for scripts.
-- When editing, add concise, meaningful comments only where logic is non-trivial.
-- Do not revert changes authored by humans unless explicitly instructed.
-- Validate any generated code snippets for TypeScript correctness and static-site compatibility (no server-only APIs).
-- Keep math notation consistent (KaTeX macros) and ensure interactive components expose accessibility hooks (keyboard, aria, reduced motion).
+- **Repository conventions**: Honor local patterns; never bypass lint/test commands when modifying code.
+- **Read-only context**: Provide patch snippets instead of direct edits when appropriate.
+- **Tool preferences**: Use `rg`, `sed`, `jq`, and CLI tools for inspection; `pnpm` for scripts.
+- **Code quality**: Add concise, meaningful comments only where logic is non-trivial.
+- **Change management**: Do not revert human-authored changes unless explicitly instructed.
+- **Validation**: Ensure generated code is TypeScript-compliant and static-site compatible.
+- **BMAD framework**: Follow structured story development and quality gate processes.
+- **Math consistency**: Maintain KaTeX macros and ensure accessibility in interactive components.
+- **Sprint awareness**: Consider current sprint context and enhancement roadmap when making changes.
 
 ## Common Pitfalls
 
-- Forgetting to add new objectives/lessons to course sequences.
-- Non-deterministic generators causing flaky spaced practice tracking.
-- Graph components without snapping/tolerance checks -> grading mismatches.
-- Missing milestone/label on new issues (violates workflow).
-- Including server-side dependencies in client components (breaks static export).
+- **Content management**: Forgetting to add new objectives/lessons to course sequences.
+- **Generator determinism**: Non-deterministic generators causing flaky spaced practice tracking.
+- **Component precision**: Graph components without snapping/tolerance checks causing grading mismatches.
+- **Workflow compliance**: Missing milestone/label on new issues (violates BMAD workflow).
+- **Static compatibility**: Including server-side dependencies in client components (breaks export).
+- **Sprint alignment**: Making changes outside current sprint scope without proper planning.
+- **Quality gates**: Bypassing QA reviews or risk assessment processes.
+- **Documentation**: Not updating sharded PRD sections when requirements evolve.
+
+## Current Project Context
+
+### Enhancement Initiative
+- **Phase**: Brownfield enhancement of functional static site
+- **Current Sprint**: S1 - Static Site Foundation (see `docs/sprint/S1.md`)
+- **Target**: Integrated Math 3 curriculum enhancement
+- **Architecture**: Maintaining static export while adding interactivity
+
+### BMAD Configuration
+- **Framework**: BMad-Method v4 with sharded PRD and architecture
+- **Story Location**: `docs/stories/` for structured development
+- **QA Process**: Risk assessment, traceability, and quality gates
+- **Agents**: Specialized roles for dev, qa, po, sm, and other functions
+- **Documentation**: Comprehensive sharded structure under `docs/`
+
+### Development Standards
+- **Language**: TypeScript with strict type checking
+- **Framework**: Next.js App Router with static export
+- **Styling**: CSS with responsive design principles
+- **Testing**: Jest for unit/integration, Playwright for E2E
+- **Linting**: ESLint with content validation rules
 
 ## Need Help?
 
-- Content or pedagogy questions → consult `docs/` (to be expanded) or raise an issue labeled `type:docs`.
-- Automation or workflow updates → propose changes in `AGENTS.md` via PR, route to maintainers for review.
-- New interactive widget ideas → draft a design doc under `docs/design/` and link in the issue before implementation.
+- **Content and pedagogy**: Consult sharded PRD (`docs/prd/`) or raise issue labeled `type:docs`.
+- **BMAD framework**: See `AGENTS.md` for agent guidance and task workflows.
+- **Sprint planning**: Refer to `docs/sprint/` for current sprint and roadmap questions.
+- **Automation and workflow**: Propose changes via PR, route to maintainers for review.
+- **Interactive components**: Draft design doc under `docs/design/` and link in issue before implementation.
+- **Quality assurance**: Consult `docs/qa/` for testing standards and gate processes.
+- **Khan Academy integration**: See `docs/automation.md` for sync and data management.
 
 <!-- BEGIN: BMAD-AGENTS -->
 # BMAD-METHOD Agents and Tasks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ This document orients automation, AI assistants, and future contributors to the 
 
 ## Repository Facts
 
-- Static Next.js application exported for GitHub Pages (`next export` → `./out`).
-- Content-first: objectives, lessons, practice generators, and flashcards live under `content/`.
-- Pedagogical focus on mastery learning, spaced retrieval, and multi-representational math instruction.
-- No runtime database or server access; all state is client-side (localStorage/IndexedDB).
+- **Functional static Next.js application** exported for GitHub Pages (`next export` → `./out`).
+- **Current enhancement phase**: Sprint S1 of 3-sprint brownfield enhancement initiative.
+- **Content-first architecture**: objectives, lessons, practice generators, and flashcards with Integrated Math 3 focus.
+- **Pedagogical foundation**: Mastery learning, spaced retrieval, and multi-representational math instruction.
+- **Client-side state**: All state managed via localStorage/IndexedDB with export/import capabilities.
+- **BMAD framework**: Structured development with specialized agents, tasks, and quality gates.
 
 ## Environment Expectations
 
@@ -21,78 +23,122 @@ This document orients automation, AI assistants, and future contributors to the 
 
 ## Content Structure
 
-- `content/objectives/`: YAML/JSON documents with IDs, titles, descriptions, prerequisites, standards, linked KA skills.
-- `content/lessons/<objectiveId>/<slug>.mdx`: Lesson narratives with embedded React components; front matter captures metadata.
-- `content/items/<objectiveId>/*.ts`: Deterministic generators exporting `generate(seed)` and `check(response)` plus hints, steps, misconception tags.
-- `content/cards/<objectiveId>.json`: Flashcard decks for spaced recall.
-- `docs/sprint/`: Sprint story breakdowns used by automation (`scripts/seed-issues.sh`) to create GitHub issues.
+- `curriculum/`: Course content and lesson materials (MDX format)
+  - `integrated-math-3.md`: Current course curriculum
+- `data/`: Static data including course information and progress tracking
+- `components/`: Interactive React components for math learning
+  - `MasteryIndicator.tsx`: Progress visualization
+  - `CurriculumOverview.tsx`: Course navigation
+- `lib/`: Utilities for content loading, progress tracking, and validation
+- `docs/`: Comprehensive project documentation
+  - `prd/`: Sharded Product Requirements Document
+  - `sprint/`: Sprint planning, roadmap, and current progress
+  - `qa/`: Quality assurance artifacts and gate reviews
+  - `architecture/`: Technical architecture and patterns
+- `app/`: Next.js app router pages and routing structure
 - `lib/`: Content loaders, RNG helpers, validation schemas, SRS utilities.
 - `components/`: Interactive widgets (FunctionGrapher, NumberLine, DragArrange, ScaffoldedSteps, etc.).
 
 ## GitHub Workflow (gh CLI)
 
-- Default branch: `main`, protected (PRs + approvals + lint/test checks required).
-- Branch naming: `<type>/<issue-number>-<kebab-title>` where `<type>` ∈ `feat|fix|chore|docs|refactor|test`.
-- Issues:
-  - Must include labels (e.g., `type:feature`, `area:frontend`, `priority:P2`) and a milestone (one sprint per milestone).
-  - Optional: add to project boards after creation.
-- Branch flow:
+- **Default branch**: `main`, protected with PRs + approvals + lint/test checks required.
+- **Branch naming**: `<type>/<issue-number>-<kebab-title>` where `<type>` ∈ `feat|fix|chore|docs|refactor|test`.
+- **Issue management**:
+  - Must include labels (e.g., `type:feature`, `area:frontend`, `priority:P2`) and sprint milestone.
+  - Optional: add to project boards for enhanced tracking.
+- **Development flow**:
   1. Create issue via `gh issue create` (include milestone, labels, assignee).
   2. Create branch from issue number.
-  3. Implement feature; keep commits Conventional.
-  4. Run `pnpm lint && pnpm test`.
+  3. Implement feature following BMAD story structure.
+  4. Run `pnpm lint && pnpm test` for validation.
   5. Push branch, open PR with `gh pr create --fill --label ... --milestone ...`.
   6. Request review, enable auto-squash merge (`gh pr merge --auto --squash`).
-  7. After merge: `git checkout main && git pull --ff-only`, delete branch locally and remote.
-- Sprint kickoff automation:
-  - Author stories in `docs/sprint/SX.md`.
-  - Dry-run issue seeding, then apply with `scripts/seed-issues.sh`.
+  7. After merge: `git checkout main && git pull --ff-only`, cleanup branches.
+- **Sprint management**:
+  - Stories authored in `docs/sprint/SX.md` with BMAD framework.
+  - Issue seeding via `scripts/seed-issues.sh` with sprint context.
   - Environment variables: `SPRINT_MILESTONE`, `ASSIGNEE`, `EXTRA_LABELS`.
+- **Quality gates**: QA reviews and automated checks ensure code quality and feature completeness.
 
 ## Testing & Quality Gates
 
-- TDD mandated: write failing tests first, then implement, then refactor.
-- Unit tests colocated with code (`*.test.ts` / `*.spec.ts`).
-- Integration tests cover lesson rendering, data wiring, and static generation.
-- Optional Playwright E2E for core flows (warmups, lesson, spaced practice).
-- Coverage goal: ≥80% on core modules (flexible during MVP).
-- Deterministic RNG: all item generators must accept `seed` and use shared helpers (e.g., `mulberry32`).
-- Accessibility checks (axe) should run on key lesson templates.
+- **TDD approach**: Write failing tests first, then implement, then refactor.
+- **Test structure**: Unit tests colocated with code (`*.test.ts` / `*.spec.ts`).
+- **Integration coverage**: Lesson rendering, data wiring, and static generation.
+- **E2E testing**: Optional Playwright for core flows (warmups, lessons, spaced practice).
+- **Coverage targets**: ≥80% on core modules (flexible during enhancement sprints).
+- **Deterministic generators**: All item generators accept `seed` parameter using shared helpers.
+- **Accessibility**: Automated checks (axe) on key lesson templates and components.
+- **BMAD quality gates**: Structured QA process with risk assessment and traceability.
+- **Static export validation**: Ensure all changes maintain GitHub Pages compatibility.
 
 ## Deployment & Automation
 
-- CI pipeline:
-  - Install dependencies.
-  - Run lint/tests.
-  - Run `pnpm build` and `next export`.
-  - Publish `/out` to `gh-pages`.
-- Required status checks: lint, unit tests, integration tests.
-- CODEOWNERS recommended for content vs. infra paths.
-- Auto-label GitHub Action (optional) to apply `area:*` labels based on file globs.
+- **CI/CD pipeline**:
+  - Install dependencies with pnpm.
+  - Run lint and test suites.
+  - Execute `pnpm build` and `next export`.
+  - Publish `/out` to `gh-pages` branch.
+- **Required checks**: Lint, unit tests, integration tests must pass.
+- **Khan Academy sync**: Automated course data updates (see `docs/automation.md`).
+- **CODEOWNERS**: Recommended for content vs. infrastructure path separation.
+- **Auto-labeling**: GitHub Actions apply `area:*` labels based on file patterns.
+- **Sprint deployments**: Regular releases aligned with sprint milestones.
 
 ## Assistant Conduct
 
-- Honor repository-local conventions; never bypass lint/test commands when modifying code.
-  - For read-only contexts, provide patch snippets instead of direct edits.
-- Prefer `rg`, `sed`, `jq`, and other CLI tools for inspection; use `pnpm` for scripts.
-- When editing, add concise, meaningful comments only where logic is non-trivial.
-- Do not revert changes authored by humans unless explicitly instructed.
-- Validate any generated code snippets for TypeScript correctness and static-site compatibility (no server-only APIs).
-- Keep math notation consistent (KaTeX macros) and ensure interactive components expose accessibility hooks (keyboard, aria, reduced motion).
+- **Repository conventions**: Honor local patterns; never bypass lint/test commands when modifying code.
+- **Read-only context**: Provide patch snippets instead of direct edits when appropriate.
+- **Tool preferences**: Use `rg`, `sed`, `jq`, and CLI tools for inspection; `pnpm` for scripts.
+- **Code quality**: Add concise, meaningful comments only where logic is non-trivial.
+- **Change management**: Do not revert human-authored changes unless explicitly instructed.
+- **Validation**: Ensure generated code is TypeScript-compliant and static-site compatible.
+- **BMAD framework**: Follow structured story development and quality gate processes.
+- **Math consistency**: Maintain KaTeX macros and ensure accessibility in interactive components.
+- **Sprint awareness**: Consider current sprint context and enhancement roadmap when making changes.
 
 ## Common Pitfalls
 
-- Forgetting to add new objectives/lessons to course sequences.
-- Non-deterministic generators causing flaky spaced practice tracking.
-- Graph components without snapping/tolerance checks -> grading mismatches.
-- Missing milestone/label on new issues (violates workflow).
-- Including server-side dependencies in client components (breaks static export).
+- **Content management**: Forgetting to add new objectives/lessons to course sequences.
+- **Generator determinism**: Non-deterministic generators causing flaky spaced practice tracking.
+- **Component precision**: Graph components without snapping/tolerance checks causing grading mismatches.
+- **Workflow compliance**: Missing milestone/label on new issues (violates BMAD workflow).
+- **Static compatibility**: Including server-side dependencies in client components (breaks export).
+- **Sprint alignment**: Making changes outside current sprint scope without proper planning.
+- **Quality gates**: Bypassing QA reviews or risk assessment processes.
+- **Documentation**: Not updating sharded PRD sections when requirements evolve.
+
+## Current Project Context
+
+### Enhancement Initiative
+- **Phase**: Brownfield enhancement of functional static site
+- **Current Sprint**: S1 - Static Site Foundation (see `docs/sprint/S1.md`)
+- **Target**: Integrated Math 3 curriculum enhancement
+- **Architecture**: Maintaining static export while adding interactivity
+
+### BMAD Configuration
+- **Framework**: BMad-Method v4 with sharded PRD and architecture
+- **Story Location**: `docs/stories/` for structured development
+- **QA Process**: Risk assessment, traceability, and quality gates
+- **Agents**: Specialized roles for dev, qa, po, sm, and other functions
+- **Documentation**: Comprehensive sharded structure under `docs/`
+
+### Development Standards
+- **Language**: TypeScript with strict type checking
+- **Framework**: Next.js App Router with static export
+- **Styling**: CSS with responsive design principles
+- **Testing**: Jest for unit/integration, Playwright for E2E
+- **Linting**: ESLint with content validation rules
 
 ## Need Help?
 
-- Content or pedagogy questions → consult `docs/` (to be expanded) or raise an issue labeled `type:docs`.
-- Automation or workflow updates → propose changes in `AGENTS.md` via PR, route to maintainers for review.
-- New interactive widget ideas → draft a design doc under `docs/design/` and link in the issue before implementation.
+- **Content and pedagogy**: Consult sharded PRD (`docs/prd/`) or raise issue labeled `type:docs`.
+- **BMAD framework**: See `AGENTS.md` for agent guidance and task workflows.
+- **Sprint planning**: Refer to `docs/sprint/` for current sprint and roadmap questions.
+- **Automation and workflow**: Propose changes via PR, route to maintainers for review.
+- **Interactive components**: Draft design doc under `docs/design/` and link in issue before implementation.
+- **Quality assurance**: Consult `docs/qa/` for testing standards and gate processes.
+- **Khan Academy integration**: See `docs/automation.md` for sync and data management.
 
 <!-- BEGIN: BMAD-AGENTS -->
 # BMAD-METHOD Agents and Tasks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A pedagogy-first, static Next.js companion to Khan Academy math courses. The site blends conceptual exploration, algorithmic scaffolding, and spaced retrieval practice to help learners build durable understanding across middle and high school mathematics.
 
+## Project Overview
+
+The KA Math Companion is a functional educational platform enhancing Khan Academy's Integrated Math 3 curriculum. We're currently in Sprint S1 of a structured enhancement initiative focusing on UI/UX improvements, interactive practice generators, and teacher tools while maintaining our static site architecture.
+
+### Current State & Sprint Focus
+
+- **Existing Foundation**: Fully functional static Next.js application with curriculum navigation and mastery tracking
+- **Current Sprint (S1)**: Static site foundation improvements and Khan Academy sync automation
+- **Enhancement Roadmap**: 3-sprint plan targeting modern UI/UX, interactive practice, and teacher dashboard
+- **Architecture**: Maintaining static export compatibility while adding client-side interactivity
+- **Content Model**: Content-first approach with objectives, lessons, and deterministic generators
+
+### Sprint Progress
+
+**Sprint S1: Static Site Foundation** (See [S1.md](docs/sprint/S1.md))
+- ✅ Basic curriculum integration and mastery indicators
+- 🔄 Enhanced static site generation and export
+- 🔄 Automated Khan Academy sync improvements
+- 🔄 Progress tracking and visualization enhancements
+
+See our [roadmap](docs/sprint/roadmap.md) for the complete 3-sprint development plan.
+
 ## Guiding Principles
 
 - **Mastery learning**: Track progress per objective; mastery requires success in scaffolded + independent practice and sustained spaced-review performance.
@@ -113,15 +135,25 @@ BR="feat/${NUM}-$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-
 git switch -c "$BR"
 ```
 
-## Roadmap Highlights
+## Development Roadmap
 
-- ✅ Architecture + content model
-- ⬜️ Implement core interactive components (FunctionGrapher, NumberLine, DragArrange)
-- ⬜️ Ship initial Algebra II objective set with generator coverage
-- ⬜️ Add Leitner SRS UI and export/import
-- ⬜️ Expand accessibility settings (reduced motion, high contrast)
-- ⬜️ Introduce SM-2 spacing option and richer analytics
-- ⬜️ Support integrated math course mappings and cross-course dashboards
+### Current Sprint (S1): Static Site Foundation
+- Enhanced static site generation and GitHub Pages deployment
+- Improved Khan Academy course sync automation (see [automation.md](docs/automation.md))
+- Progress tracking and mastery visualization improvements
+- Content structure optimization for Integrated Math 3
+
+### Upcoming Sprints
+- **S2**: Interactive Practice Components - FunctionGrapher, NumberLine, DragArrange
+- **S3**: Teacher Dashboard & Analytics - Comprehensive tools for educators
+
+### Long-term Vision
+- SM-2 spacing algorithm and richer analytics
+- Expanded accessibility settings (reduced motion, high contrast)
+- Cross-course dashboards and integrated math mappings
+- Advanced gamification and engagement features
+
+See [roadmap.md](docs/sprint/roadmap.md) for detailed planning and [PRD](docs/prd/) for comprehensive requirements.
 
 ---
 
@@ -133,5 +165,18 @@ git switch -c "$BR"
 4. Request review via `gh pr edit --add-reviewer`.
 5. Enable auto-merge (`gh pr merge --auto --squash`).
 6. After merge, sync `main` and delete the feature branch locally and remote.
+
+## BMAD Framework & Documentation
+
+This project uses the BMad-Method framework for structured development:
+- **Agents**: Specialized AI assistants for different roles (see [AGENTS.md](AGENTS.md))
+- **Tasks**: Reusable workflows for development activities
+- **Documentation**: Structured PRD, architecture, and quality assurance
+
+### Key Documentation
+- [Product Requirements](docs/prd/) - Sharded PRD with comprehensive feature planning
+- [Sprint Planning](docs/sprint/) - Current sprint and roadmap
+- [Automation Guide](docs/automation.md) - Khan Academy sync and CI/CD
+- [Architecture Guide](docs/architecture/) - Technical architecture and patterns
 
 See `AGENTS.md` for automation and assistant guidance.

--- a/app/curriculum/CurriculumOverview.test.tsx
+++ b/app/curriculum/CurriculumOverview.test.tsx
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, expect, it } from "vitest";
 import { JSDOM } from "jsdom";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -8,7 +7,8 @@ import { DEFAULT_CURRICULUM_SLUG, getCurriculum } from "../../lib/getCurriculum"
 import { MasteryIndicator } from "../../components/MasteryIndicator";
 import { CurriculumOverview } from "./CurriculumOverview";
 
-test("MasteryIndicator renders in curriculum context", () => {
+describe("CurriculumOverview", () => {
+  it("renders mastery indicator in curriculum context", () => {
   // Test that the MasteryIndicator component can render with different progress states
   const progressStates = [
     { lessonId: 'test-1', attempts: 0, correctAttempts: 0, lastAttemptDate: null, masteryLevel: 'not-started' as const, hintsUsed: 0, spacedPracticeStreak: 0 },
@@ -23,10 +23,10 @@ test("MasteryIndicator renders in curriculum context", () => {
     const { document } = new JSDOM(markup).window;
     
     const indicator = document.querySelector('[role="img"]');
-    assert.ok(indicator, "indicator should render");
+    expect(indicator).toBeTruthy();
     
     const ariaLabel = indicator?.getAttribute('aria-label');
-    assert.ok(ariaLabel, "should have accessibility label");
+    expect(ariaLabel).toBeTruthy();
     
     // Check for the human-readable label, not the internal enum value
     const expectedLabels = {
@@ -37,29 +37,29 @@ test("MasteryIndicator renders in curriculum context", () => {
       'overlearned': 'Overlearned',
     };
     const expectedLabel = expectedLabels[progress.masteryLevel];
-    assert.ok(ariaLabel?.includes(expectedLabel), 
-      `label should include ${expectedLabel}`);
+      expect(ariaLabel?.includes(expectedLabel)).toBe(true);
   });
-});
+  });
 
-test("CurriculumOverview lists units with static lesson links", () => {
-  const course = getCurriculum(DEFAULT_CURRICULUM_SLUG);
-  const markup = renderToStaticMarkup(
-    <CurriculumOverview course={course} courseSlug={DEFAULT_CURRICULUM_SLUG} />
-  );
-  const { document } = new JSDOM(markup).window;
+  it("lists units with static lesson links", () => {
+    const course = getCurriculum(DEFAULT_CURRICULUM_SLUG);
+    const markup = renderToStaticMarkup(
+      <CurriculumOverview course={course} courseSlug={DEFAULT_CURRICULUM_SLUG} />
+    );
+    const { document } = new JSDOM(markup).window;
 
-  const overview = document.querySelector('[data-testid="curriculum-overview"]');
-  assert.ok(overview, "curriculum overview wrapper should render");
+    const overview = document.querySelector('[data-testid="curriculum-overview"]');
+    expect(overview).toBeTruthy();
 
-  const lessonCountNodes = document.querySelectorAll('[data-testid="lessons-count"]');
-  assert.ok(lessonCountNodes.length > 0, "lesson counts should be present for each unit");
+    const lessonCountNodes = document.querySelectorAll('[data-testid="lessons-count"]');
+    expect(lessonCountNodes.length).toBeGreaterThan(0);
 
-  const firstLessonLink = document.querySelector('.unit-lessons-list a');
-  assert.ok(firstLessonLink, "at least one lesson link should render");
+    const firstLessonLink = document.querySelector('.unit-lessons-list a');
+    expect(firstLessonLink).toBeTruthy();
 
-  const href = firstLessonLink?.getAttribute("href");
-  assert.ok(href, "lesson link should include href");
-  assert.ok(href?.startsWith(`/curriculum/${DEFAULT_CURRICULUM_SLUG}/`), "lesson link must be statically routed");
-  assert.ok(!href?.includes("?"), "lesson link should avoid query parameters for static export");
+    const href = firstLessonLink?.getAttribute("href");
+    expect(href).toBeTruthy();
+    expect(href?.startsWith(`/curriculum/${DEFAULT_CURRICULUM_SLUG}/`)).toBe(true);
+    expect(href?.includes("?")).toBe(false);
+  });
 });

--- a/app/curriculum/[courseSlug]/page.tsx
+++ b/app/curriculum/[courseSlug]/page.tsx
@@ -10,9 +10,9 @@ import {
 import { CurriculumOverview } from "../CurriculumOverview";
 
 type PageProps = {
-  params: {
+  params: Promise<{
     courseSlug: string;
-  };
+  }>;
 };
 
 function tryGetCurriculum(slug: string): CurriculumCourse | null {
@@ -31,7 +31,7 @@ export function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { courseSlug } = params;
+  const { courseSlug } = await params;
   const course = tryGetCurriculum(courseSlug);
   if (!course) {
     return {
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function CurriculumCoursePage({ params }: PageProps) {
-  const { courseSlug } = params;
+  const { courseSlug } = await params;
   const course = tryGetCurriculum(courseSlug);
 
   if (!course) {

--- a/components/MasteryIndicator.test.tsx
+++ b/components/MasteryIndicator.test.tsx
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, expect, it } from "vitest";
 import { JSDOM } from "jsdom";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -19,110 +18,109 @@ function createMockProgress(level: LessonProgress['masteryLevel']): LessonProgre
   };
 }
 
-test("MasteryIndicator renders different mastery levels", () => {
-  const levels: LessonProgress['masteryLevel'][] = [
-    'not-started', 'struggling', 'progressing', 'mastered', 'overlearned'
-  ];
-  
-  levels.forEach(level => {
-    const progress = createMockProgress(level);
+describe("MasteryIndicator", () => {
+  it("renders different mastery levels", () => {
+    const levels: LessonProgress['masteryLevel'][] = [
+      'not-started', 'struggling', 'progressing', 'mastered', 'overlearned'
+    ];
+
+    levels.forEach(level => {
+      const progress = createMockProgress(level);
+      const markup = renderToStaticMarkup(
+        <MasteryIndicator progress={progress} />
+      );
+      const { document } = new JSDOM(markup).window;
+
+      const indicator = document.querySelector('[role="img"]');
+      expect(indicator).toBeTruthy();
+
+      const ariaLabel = indicator?.getAttribute('aria-label');
+      expect(ariaLabel).toBeTruthy();
+
+      const expectedLabels = {
+        'not-started': 'Not started',
+        'struggling': 'Struggling',
+        'progressing': 'Progressing',
+        'mastered': 'Mastered',
+        'overlearned': 'Overlearned',
+      };
+      const expectedLabel = expectedLabels[level];
+      expect(ariaLabel?.includes(expectedLabel)).toBe(true);
+    });
+  });
+
+  it("shows label when requested", () => {
+    const progress = createMockProgress('mastered');
+    const markup = renderToStaticMarkup(
+      <MasteryIndicator progress={progress} showLabel={true} />
+    );
+    const { document } = new JSDOM(markup).window;
+
+    const label = document.querySelector('span:not([aria-hidden])');
+    expect(label).toBeTruthy();
+    expect(label?.textContent || '').toMatch(/Mastered/);
+  });
+
+  it("applies size classes correctly", () => {
+    const progress = createMockProgress('progressing');
+
+    const sizes = ['small', 'medium', 'large'] as const;
+    const expectedSizes = [
+      { width: '16px', height: '16px' },
+      { width: '20px', height: '20px' },
+      { width: '24px', height: '24px' },
+    ];
+
+    sizes.forEach((size, index) => {
+      const markup = renderToStaticMarkup(
+        <MasteryIndicator progress={progress} size={size} />
+      );
+      const { document } = new JSDOM(markup).window;
+
+      const container = document.querySelector('.mastery-indicator');
+      expect(container).toBeTruthy();
+
+      const style = container?.getAttribute('style') || '';
+      expect(style.includes(`width:${expectedSizes[index].width}`)).toBe(true);
+      expect(style.includes(`height:${expectedSizes[index].height}`)).toBe(true);
+    });
+  });
+
+  it("has proper accessibility attributes", () => {
+    const progress = createMockProgress('struggling');
     const markup = renderToStaticMarkup(
       <MasteryIndicator progress={progress} />
     );
     const { document } = new JSDOM(markup).window;
-    
+
     const indicator = document.querySelector('[role="img"]');
-    assert.ok(indicator, "indicator should have role=img");
-    
+    expect(indicator).toBeTruthy();
+
     const ariaLabel = indicator?.getAttribute('aria-label');
-    assert.ok(ariaLabel, "indicator should have aria-label");
-    
-    // Check for the human-readable label, not the internal enum value
-    const expectedLabels = {
-      'not-started': 'Not started',
-      'struggling': 'Struggling', 
-      'progressing': 'Progressing',
-      'mastered': 'Mastered',
-      'overlearned': 'Overlearned',
-    };
-    const expectedLabel = expectedLabels[level];
-    assert.ok(ariaLabel?.includes(expectedLabel), `aria-label should include ${expectedLabel}`);
+    expect(ariaLabel).toBeTruthy();
+    expect(ariaLabel?.includes('Struggling')).toBe(true);
+    expect(ariaLabel?.includes('Less than 50% correct')).toBe(true);
+
+    const title = indicator?.querySelector('div')?.getAttribute('title');
+    expect(title).toBe("Less than 50% correct");
   });
 });
 
-test("MasteryIndicator shows label when requested", () => {
-  const progress = createMockProgress('mastered');
-  const markup = renderToStaticMarkup(
-    <MasteryIndicator progress={progress} showLabel={true} />
-  );
-  const { document } = new JSDOM(markup).window;
-  
-  const label = document.querySelector('span:not([aria-hidden])');
-  assert.ok(label, "label should be visible when showLabel=true");
-  assert.match(label?.textContent || '', /Mastered/, "label should show mastery level");
-});
-
-test("MasteryIndicator applies size classes correctly", () => {
-  const progress = createMockProgress('progressing');
-  
-  const sizes = ['small', 'medium', 'large'] as const;
-  const expectedSizes = [
-    { width: '16px', height: '16px' },
-    { width: '20px', height: '20px' },
-    { width: '24px', height: '24px' },
-  ];
-  
-  sizes.forEach((size, index) => {
-    const markup = renderToStaticMarkup(
-      <MasteryIndicator progress={progress} size={size} />
-    );
+describe("MasteryLegend", () => {
+  it("renders all mastery levels", () => {
+    const markup = renderToStaticMarkup(<MasteryLegend />);
     const { document } = new JSDOM(markup).window;
-    
-    const container = document.querySelector('.mastery-indicator');
-    assert.ok(container, "container should exist");
-    
-    const style = container?.getAttribute('style') || '';
-    assert.ok(style.includes(`width:${expectedSizes[index].width}`), 
-      `size ${size} should have width ${expectedSizes[index].width}`);
-    assert.ok(style.includes(`height:${expectedSizes[index].height}`), 
-      `size ${size} should have height ${expectedSizes[index].height}`);
-  });
-});
 
-test("MasteryLegend renders all mastery levels", () => {
-  const markup = renderToStaticMarkup(<MasteryLegend />);
-  const { document } = new JSDOM(markup).window;
-  
-  const indicators = document.querySelectorAll('[role="listitem"]');
-  assert.equal(indicators.length, 5, "should show 5 mastery levels");
-  
-  const labels = Array.from(indicators as NodeListOf<Element>).map(item => 
-    item.textContent?.trim()
-  );
-  
-  const expectedLabels = ['Not started', 'Struggling', 'Progressing', 'Mastered', 'Overlearned'];
-  expectedLabels.forEach(expected => {
-    assert.ok(labels.some(label => label?.includes(expected)), 
-      `should include label: ${expected}`);
-  });
-});
+    const indicators = document.querySelectorAll('[role="listitem"]');
+    expect(indicators.length).toBe(5);
 
-test("MasteryIndicator has proper accessibility attributes", () => {
-  const progress = createMockProgress('struggling');
-  const markup = renderToStaticMarkup(
-    <MasteryIndicator progress={progress} />
-  );
-  const { document } = new JSDOM(markup).window;
-  
-  const indicator = document.querySelector('[role="img"]');
-  assert.ok(indicator, "should have role=img");
-  
-  const ariaLabel = indicator?.getAttribute('aria-label');
-  assert.ok(ariaLabel, "should have aria-label");
-  assert.ok(ariaLabel?.includes('Struggling'), "aria-label should describe status");
-  assert.ok(ariaLabel?.includes('Less than 50% correct'), "aria-label should give details");
-  
-  const title = indicator?.querySelector('div')?.getAttribute('title');
-  assert.ok(title, "should have title attribute");
-  assert.equal(title, "Less than 50% correct");
+    const labels = Array.from(indicators as NodeListOf<Element>).map(item =>
+      item.textContent?.trim()
+    );
+
+    const expectedLabels = ['Not started', 'Struggling', 'Progressing', 'Mastered', 'Overlearned'];
+    expectedLabels.forEach(expected => {
+      expect(labels.some(label => label?.includes(expected))).toBe(true);
+    });
+  });
 });

--- a/docs/brief.md
+++ b/docs/brief.md
@@ -1,0 +1,233 @@
+# KA Math Companion - Project Brief
+
+## Executive Summary
+
+KA Math Companion is a dual-platform educational enhancement system that transforms Khan Academy's Integrated Math 3 curriculum into an engaging, mastery-based learning experience. The project addresses the critical gap between static video content and active learning by creating two interconnected platforms: a Teacher Presentation System featuring dynamic slide decks with embedded practice generators, and a Student RPG Learning System that gamifies mathematical concepts through narrative-driven gameplay.
+
+This hybrid approach leverages Khan Academy's comprehensive curriculum while solving the engagement and practice challenges faced by both educators and students. Teachers gain presentation-ready materials that eliminate manual content preparation, while students experience mathematics through an immersive role-playing game that provides contextualized practice and immediate feedback. The system maintains pedagogical rigor while dramatically increasing student motivation and teacher efficiency.
+
+## Problem Statement
+
+### Teacher Pain Points
+- **Content Preparation Overhead**: Teachers spend excessive time creating supplementary materials, practice problems, and assessments from Khan Academy videos
+- **Engagement Challenges**: Static video content fails to maintain student attention, leading to passive learning and reduced comprehension
+- **Assessment Gaps**: Limited tools for real-time understanding checks and differentiated instruction during lessons
+- **Resource Fragmentation**: No unified system that combines curriculum delivery, practice generation, and progress tracking
+
+### Student Pain Points
+- **Passive Learning Experience**: Traditional video consumption leads to low engagement and poor knowledge retention
+- **Abstract Concept Disconnect**: Students struggle to connect mathematical concepts to real-world applications
+- **Practice Motivation**: Repetitive problem sets lack context and fail to inspire continued practice
+- **Progress Visibility**: Limited insight into mastery levels and learning pathways
+
+## Proposed Solution
+
+### Dual-Platform Architecture
+
+#### 1. Teacher Presentation System
+- **Dynamic Slide Decks**: Auto-generated presentations aligned with Khan Academy's Integrated Math 3 curriculum
+- **Embedded Practice Generators**: Interactive problem sets integrated directly into presentation flow
+- **Real-time Assessment Tools**: Quick checks for understanding with immediate class-wide feedback
+- **Progress Tracking Dashboard**: Visual representation of class and individual student mastery levels
+
+#### 2. Student RPG Learning System
+- **Narrative-Driven Gameplay**: Mathematical concepts embedded in an engaging role-playing game storyline
+- **Contextualized Practice**: Problems presented within game scenarios that demonstrate real-world applications
+- **Adaptive Difficulty**: Challenge scaling based on individual student performance and mastery indicators
+- **Achievement System**: Badges, level progression, and narrative advancement tied to mathematical competency
+
+### Integration Benefits
+- **Unified Curriculum**: Both platforms draw from the same Khan Academy content pool ensuring consistency
+- **Data Synchronization**: Student progress in RPG system informs teacher dashboard for targeted intervention
+- **Flexible Implementation**: Teachers can use presentation system independently or as part of full ecosystem
+
+## Target Users
+
+### Primary Users: Teachers
+- **Mathematics Educators**: Middle school and high school teachers using Integrated Math 3 curriculum
+- **Instructional Designers**: Educational specialists creating supplemental learning materials
+- **Tutors**: Private educators seeking structured, engaging mathematical content delivery
+
+**User Characteristics:**
+- Familiar with Khan Academy content structure
+- Seek to enhance student engagement without sacrificing curriculum standards
+- Value time-saving tools that maintain pedagogical quality
+- Require flexibility for different classroom environments and student needs
+
+### Secondary Users: Students
+- **Integrated Math 3 Learners**: Students aged 13-16 enrolled in corresponding mathematics courses
+- **Independent Learners**: Self-motivated students seeking additional practice and understanding
+- **Struggling Students**: Learners requiring alternative approaches to grasp mathematical concepts
+
+**User Characteristics:**
+- Comfortable with digital learning platforms and game-based learning
+- Respond positively to immediate feedback and progress visualization
+- Benefit from contextualized learning that connects abstract concepts to tangible scenarios
+- Require varying levels of challenge based on individual competency
+
+## Goals & Success Metrics
+
+### Teacher-Focused Goals
+1. **Reduce Preparation Time**: Decrease time spent creating supplementary materials by 75%
+2. **Increase Engagement**: Achieve 85% student engagement during mathematics lessons
+3. **Improve Assessment Efficiency**: Enable real-time understanding checks for entire class within 2 minutes
+4. **Enhance Instruction Quality**: Provide teachers with data-driven insights for differentiated instruction
+
+**Success Metrics:**
+- Average time saved per lesson preparation
+- Student engagement scores during presentation use
+- Frequency and effectiveness of real-time assessments
+- Teacher satisfaction and adoption rates
+
+### Student-Focused Goals
+1. **Boost Learning Motivation**: Increase voluntary practice time by 60% through gamification
+2. **Improve Concept Mastery**: Achieve 90% mastery rate on core mathematical concepts
+3. **Enhance Retention**: Improve long-term retention of mathematical concepts by 40%
+4. **Develop Problem-Solving Skills**: Increase application of mathematical concepts to novel scenarios
+
+**Success Metrics:**
+- Daily active users and average session duration in RPG system
+- Mastery level progression and concept completion rates
+- Performance on assessments comparing traditional vs. RPG-enhanced learning
+- Student self-reported confidence and enjoyment scores
+
+## MVP Scope
+
+### Teacher Presentation System (Phase 1)
+**Core Features:**
+- Slide deck generation for first 3 Khan Academy Integrated Math 3 units
+- Embedded practice problem generators with immediate feedback
+- Basic progress tracking for individual students
+- Export functionality for offline presentation use
+
+**Technical Implementation:**
+- Integration with Khan Academy's content API
+- Deterministic practice problem generation algorithms
+- Responsive web-based presentation interface
+- Local storage for student progress data
+
+### Student RPG System Foundation (Phase 1)
+**Core Features:**
+- Character creation and basic narrative framework
+- Mathematical concept integration for first 3 units
+- Practice problems embedded in game scenarios
+- Basic achievement and progression system
+
+**Technical Implementation:**
+- Game engine using web technologies (React/TypeScript)
+- Content management system for mathematical problems
+- Save system for game progress and achievement data
+- Mobile-responsive design for tablet compatibility
+
+### Integration Features
+- Unified user authentication across both platforms
+- Progress synchronization between teacher dashboard and student game
+- Shared content database ensuring curriculum alignment
+
+## Post-MVP Vision
+
+### Complete Curriculum Integration (Phase 2)
+- **Full 180-Day Coverage**: Expand to complete Khan Academy Integrated Math 3 curriculum
+- **Advanced Assessment Tools**: Comprehensive testing suite with detailed analytics
+- **Collaborative Features**: Student group activities and competitive challenges
+- **Parent Portal**: Progress tracking and communication tools for family engagement
+
+### Enhanced RPG Experience (Phase 3)
+- **Multiplayer Capabilities**: Collaborative problem-solving and team-based challenges
+- **Adaptive Learning Paths**: Personalized curriculum progression based on performance
+- **Virtual Reality Integration**: Immersive mathematical environments for complex concepts
+- **Cross-Curricular Connections**: Integration with science and engineering applications
+
+### Platform Expansion (Phase 4)
+- **Additional Mathematics Courses**: Algebra 1, Geometry, Algebra 2, and Precalculus
+- **Subject Area Expansion**: Science, engineering, and computational thinking modules
+- **School District Integration**: Administrative tools for system-wide implementation
+- **Professional Development**: Teacher training and certification programs
+
+## Technical Considerations
+
+### Architecture Requirements
+- **Microservices Design**: Separate services for content management, user authentication, and game logic
+- **API-First Approach**: RESTful APIs enabling third-party integrations and future mobile applications
+- **Scalable Infrastructure**: Cloud-based architecture supporting concurrent user growth
+- **Data Analytics Pipeline**: Real-time processing of user interactions for adaptive learning
+
+### Technology Stack
+- **Frontend**: React with TypeScript for consistency across platforms
+- **Backend**: Node.js with Express for API services
+- **Database**: PostgreSQL for structured data, Redis for caching and session management
+- **Content Delivery**: CDN integration for efficient slide deck and game asset distribution
+- **Authentication**: OAuth 2.0 with potential for school district SSO integration
+
+### Content Management
+- **Automated Content Sync**: Regular synchronization with Khan Academy curriculum updates
+- **Version Control**: Tracking of curriculum changes and content modifications
+- **Quality Assurance**: Automated testing of practice problems and game scenarios
+- **Accessibility**: WCAG 2.1 compliance for inclusive learning experiences
+
+## Constraints & Assumptions
+
+### Technical Constraints
+- **Khan Academy API Limitations**: Dependency on external API availability and rate limits
+- **Browser Compatibility**: Support for modern browsers required; legacy browser support limited
+- **Offline Functionality**: Limited offline capabilities due to content synchronization requirements
+- **Mobile Performance**: RPG system performance optimization for various device capabilities
+
+### Educational Constraints
+- **Curriculum Alignment**: Must maintain strict adherence to Khan Academy's learning objectives
+- **Assessment Standards**: Compliance with educational assessment standards and privacy regulations
+- **Age Appropriateness**: Content and game mechanics suitable for 13-16 age demographic
+- **Accessibility Requirements**: Support for students with diverse learning needs and abilities
+
+### Business Constraints
+- **Development Timeline**: MVP delivery within 6-month development cycle
+- **Resource Allocation**: Limited development team requiring efficient feature prioritization
+- **Monetization Strategy**: Sustainable business model without compromising educational access
+- **Partnership Dependencies**: Potential reliance on educational institutions for adoption
+
+### Key Assumptions
+- **Teacher Adoption**: Educators will embrace technology-enhanced teaching tools
+- **Student Engagement**: Game-based learning will increase mathematical practice motivation
+- **Technical Literacy**: Target users possess sufficient digital skills for platform navigation
+- **Infrastructure Access**: Schools and students have reliable internet access and compatible devices
+
+## Risks & Open Questions
+
+### Technical Risks
+- **API Dependency**: Khan Academy API changes could disrupt content synchronization
+- **Scalability Challenges**: Performance issues with high concurrent user loads
+- **Cross-Platform Compatibility**: Maintaining consistent experience across diverse devices
+- **Data Security**: Protecting student privacy and educational data
+
+### Educational Risks
+- **Learning Effectiveness**: Uncertainty about gamification impact on mathematical comprehension
+- **Teacher Resistance**: Potential pushback against technology replacing traditional methods
+- **Curriculum Drift**: Risk of game mechanics overshadowing educational objectives
+- **Equity Concerns**: Potential widening of achievement gaps based on technology access
+
+### Business Risks
+- **Market Adoption**: Uncertainty about school district and teacher adoption rates
+- **Competitive Landscape**: Existing educational technology solutions with established market presence
+- **Funding Sustainability**: Long-term financial viability without compromising educational mission
+- **Partnership Dependencies**: Reliance on educational institutions for implementation success
+
+### Open Questions for Research
+1. **Optimal Game Balance**: What is the ideal ratio of entertainment to educational content?
+2. **Assessment Integration**: How can game-based learning effectively measure mathematical mastery?
+3. **Teacher Training**: What level of professional development is required for successful implementation?
+4. **Parent Engagement**: How can families be effectively involved in the learning ecosystem?
+5. **Long-term Impact**: What are the longitudinal effects on mathematical achievement and career choices?
+
+### Mitigation Strategies
+- **Phased Rollout**: Gradual implementation with continuous feedback collection
+- **Pilot Programs**: Controlled testing with diverse educational environments
+- **Educational Partnerships**: Collaboration with mathematics education researchers
+- **Iterative Development**: Agile methodology allowing for rapid adjustment based on user feedback
+- **Alternative Content Strategies**: Backup plans for content delivery if API limitations arise
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: October 4, 2025  
+**Next Review**: November 1, 2025  
+**Stakeholders**: Development Team, Educational Advisors, Khan Academy Partnership Team

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,30 @@
+# KA Math Companion - Product Requirements Document
+
+## 📑 Sharded Document Notice
+
+This PRD has been sharded for better navigation and management. Please access the content through the organized sections in the [docs/prd/](./prd/) directory.
+
+## 📁 Document Structure
+
+The PRD is organized into the following sections:
+
+- **[Introduction and Project Context](./prd/introduction.md)** - Project overview and current system state
+- **[Requirements](./prd/requirements.md)** - Functional, non-functional, and compatibility requirements  
+- **[User Interface Enhancement Goals](./prd/ui-enhancement-goals.md)** - Design philosophy and UX improvements
+- **[Technical Constraints](./prd/technical-constraints.md)** - Architecture and integration requirements
+- **[Epic and Story Structure](./prd/epic-structure.md)** - Organization of development work
+- **[Epic Details](./prd/epic-details.md)** - Detailed epic and story definitions
+
+## 🚀 Quick Access
+
+- **[Start Here → Introduction](./prd/introduction.md)**
+- **[For Developers → Epic Details](./prd/epic-details.md)**
+- **[For Designers → UI Enhancement Goals](./prd/ui-enhancement-goals.md)**
+- **[For Architects → Technical Constraints](./prd/technical-constraints.md)**
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: October 4, 2025  
+**Next Review**: November 1, 2025  
+**Stakeholders**: Development Team, Product Owner, UX Team

--- a/docs/prd/epic-details.md
+++ b/docs/prd/epic-details.md
@@ -1,0 +1,223 @@
+# Epic Details
+
+## Epic 1: Foundation and Infrastructure
+
+### Epic Goal
+Establish the technical foundation and infrastructure required to support all UI enhancements while maintaining system stability and performance.
+
+### Stories
+
+#### Story 1.1: Upgrade Build System and Tooling
+**User Story**: As a developer, I want an upgraded build system with modern tooling, so that I can develop more efficiently with better debugging and testing capabilities.
+
+**Acceptance Criteria**:
+- Modern build configuration with webpack 5 or Vite
+- Enhanced development server with hot module replacement
+- Improved debugging capabilities with source maps
+- Automated testing integration with Jest and React Testing Library
+- Code quality tools integration (ESLint, Prettier, TypeScript)
+
+#### Story 1.2: Implement Design System Foundation
+**User Story**: As a developer, I want a design system foundation, so that I can build consistent UI components across the application.
+
+**Acceptance Criteria**:
+- Design tokens for colors, typography, spacing, and shadows
+- Base component library with Button, Input, Card, and Modal components
+- Theme system supporting light and dark modes
+- Component documentation with Storybook integration
+- Accessibility compliance for all base components
+
+#### Story 1.3: Enhanced State Management
+**User Story**: As a developer, I want enhanced state management, so that I can efficiently manage complex application state and data flow.
+
+**Acceptance Criteria**:
+- Redux Toolkit or Zustand implementation for global state
+- Local state management patterns for component state
+- Data fetching and caching with React Query or SWR
+- State persistence for user preferences and progress
+- Performance optimization with memoization and selective updates
+
+## Epic 2: Core UI Components
+
+### Epic Goal
+Develop a comprehensive library of reusable UI components that provide consistent user experience and accelerate feature development.
+
+### Stories
+
+#### Story 2.1: Navigation Components
+**User Story**: As a user, I want intuitive navigation components, so that I can easily move through the application and find content quickly.
+
+**Acceptance Criteria**:
+- Responsive navigation header with mobile menu
+- Breadcrumb navigation for content hierarchy
+- Tab navigation for content organization
+- Search functionality with autocomplete
+- Keyboard navigation support for accessibility
+
+#### Story 2.2: Content Display Components
+**User Story**: As a user, I want well-designed content display components, so that I can consume educational content effectively.
+
+**Acceptance Criteria**:
+- Lesson card components with progress indicators
+- Content viewer with responsive typography
+- Media components for video and interactive content
+- Progress visualization components
+- Bookmark and favorite functionality
+
+#### Story 2.3: Form and Input Components
+**User Story**: As a user, I want intuitive form components, so that I can easily input information and interact with the system.
+
+**Acceptance Criteria**:
+- Form validation with real-time feedback
+- Accessible form labels and error messages
+- File upload components for assignments
+- Rich text editor for content creation
+- Auto-save functionality for form inputs
+
+## Epic 3: Navigation and Layout
+
+### Epic Goal
+Redesign the application navigation structure and layout to improve user flow, information architecture, and overall usability.
+
+### Stories
+
+#### Story 3.1: Responsive Layout System
+**User Story**: As a user, I want a responsive layout that works well on all my devices, so that I can access the application anywhere.
+
+**Acceptance Criteria**:
+- Mobile-first responsive design
+- Grid-based layout system
+- Flexible sidebar navigation
+- Adaptive content areas
+- Touch-friendly interface elements
+
+#### Story 3.2: Enhanced Information Architecture
+**User Story**: As a user, I want clear information architecture, so that I can find what I need quickly and understand the content structure.
+
+**Acceptance Criteria**:
+- Improved content categorization and organization
+- Clear visual hierarchy
+- Consistent navigation patterns
+- Content filtering and sorting options
+- Advanced search capabilities
+
+#### Story 3.3: User Dashboard Redesign
+**User Story**: As a user, I want a personalized dashboard, so that I can see my progress and access relevant content quickly.
+
+**Acceptance Criteria**:
+- Personalized content recommendations
+- Progress overview and statistics
+- Quick access to recent activity
+- Customizable dashboard widgets
+- Goal setting and tracking
+
+## Epic 4: Interactive Practice System
+
+### Epic Goal
+Build an enhanced practice system with interactive problems, immediate feedback, and adaptive difficulty to improve learning outcomes.
+
+### Stories
+
+#### Story 4.1: Interactive Problem Generator
+**User Story**: As a student, I want interactive practice problems, so that I can engage with mathematical concepts in a dynamic way.
+
+**Acceptance Criteria**:
+- Dynamic problem generation with multiple difficulty levels
+- Interactive problem types (drag-and-drop, multiple choice, input)
+- Step-by-step problem solving guidance
+- Immediate feedback on answers
+- Hint system for struggling students
+
+#### Story 4.2: Real-time Feedback System
+**User Story**: As a student, I want immediate feedback on my work, so that I can learn from my mistakes and improve quickly.
+
+**Acceptance Criteria**:
+- Instant answer validation
+- Detailed explanation of correct solutions
+- Common mistake identification and correction
+- Progress tracking for practice sessions
+- Performance analytics and insights
+
+#### Story 4.3: Adaptive Learning Engine
+**User Story**: As a student, I want adaptive difficulty, so that I can work at the right level and stay challenged but not overwhelmed.
+
+**Acceptance Criteria**:
+- Performance-based difficulty adjustment
+- Personalized learning path recommendations
+- Knowledge gap identification
+- Mastery-based progression
+- Review and reinforcement scheduling
+
+## Epic 5: Teacher Dashboard
+
+### Epic Goal
+Develop comprehensive teacher tools for class management, student monitoring, and instructional support.
+
+### Stories
+
+#### Story 5.1: Class Management Interface
+**User Story**: As a teacher, I want comprehensive class management tools, so that I can effectively organize and monitor my students' learning.
+
+**Acceptance Criteria**:
+- Student roster management
+- Class creation and configuration
+- Assignment creation and distribution
+- Grade book and progress tracking
+- Communication tools for students
+
+#### Story 5.2: Analytics and Reporting
+**User Story**: As a teacher, I want detailed analytics and reporting, so that I can understand student performance and tailor my instruction.
+
+**Acceptance Criteria**:
+- Individual student progress reports
+- Class performance analytics
+- Learning objective mastery tracking
+- Time-on-task and engagement metrics
+- Exportable reports for administrators
+
+#### Story 5.3: Assessment Tools
+**User Story**: As a teacher, I want advanced assessment tools, so that I can create comprehensive evaluations of student learning.
+
+**Acceptance Criteria**:
+- Custom assessment creation
+- Automated grading and feedback
+- Performance analysis and insights
+- Differentiated instruction recommendations
+- Parent communication tools
+
+## Epic 6: Student Experience Enhancements
+
+### Epic Goal
+Enhance the student learning experience with gamification, social features, and personalized learning paths.
+
+### Stories
+
+#### Story 6.1: Gamification System
+**User Story**: As a student, I want gamification elements, so that I can stay motivated and engaged in my learning.
+
+**Acceptance Criteria**:
+- Points and achievement system
+- Progress badges and milestones
+- Learning streaks and challenges
+- Leaderboards and competitions
+- Reward redemption system
+
+#### Story 6.2: Social Learning Features
+**User Story**: As a student, I want social learning features, so that I can collaborate with peers and learn together.
+
+**Acceptance Criteria**:
+- Study group creation and management
+- Peer tutoring and help system
+- Collaborative problem solving
+- Discussion forums and Q&A
+- Project-based learning activities
+
+#### Story 6.3: Personalized Learning Paths
+**User Story**: As a student, I want personalized learning paths, so that I can learn at my own pace and focus on areas where I need improvement.
+
+**Acceptance Criteria**:
+- Personalized content recommendations
+- Adaptive learning sequences
+- Learning style accommodations
+- Interest-based content connections
+- Goal setting and progress planning

--- a/docs/prd/epic-structure.md
+++ b/docs/prd/epic-structure.md
@@ -1,0 +1,134 @@
+# Epic and Story Structure
+
+## Epic Organization
+
+The enhancement work is organized into focused epics that build upon each other to deliver the complete UI enhancement vision. Each epic contains multiple user stories that break down the work into manageable, deliverable increments.
+
+### Epic Hierarchy
+
+1. **Epic 1: Foundation and Infrastructure**
+   - Establishes the technical foundation for UI enhancements
+   - Includes core architecture improvements and tooling setup
+   - Prerequisite for all subsequent epics
+
+2. **Epic 2: Core UI Components**
+   - Develops the reusable component library
+   - Implements the design system and visual improvements
+   - Provides building blocks for feature development
+
+3. **Epic 3: Navigation and Layout**
+   - Redesigns the application navigation structure
+   - Implements responsive layout improvements
+   - Enhances the overall user flow and information architecture
+
+4. **Epic 4: Interactive Practice System**
+   - Builds the enhanced practice problem generators
+   - Implements real-time feedback and assessment tools
+   - Creates engaging interactive learning experiences
+
+5. **Epic 5: Teacher Dashboard**
+   - Develops comprehensive teacher tools
+   - Implements class management and analytics
+   - Provides insights into student progress and performance
+
+6. **Epic 6: Student Experience Enhancements**
+   - Focuses on student-facing improvements
+   - Implements gamification and engagement features
+   - Enhances the learning journey and progress visualization
+
+## Story Structure
+
+### User Story Format
+
+Each user story follows the standard format:
+```
+As a [user type],
+I want [functionality],
+so that [benefit/value].
+```
+
+### Story Components
+
+Each story includes:
+- **User Story**: Clear statement of user need and value
+- **Acceptance Criteria**: Specific, testable requirements
+- **Technical Notes**: Implementation guidance and constraints
+- **Tasks**: Breakdown of development work
+- **Definition of Done**: Completion criteria
+
+### Story Sizing
+
+Stories are sized to be completed in 1-3 days of focused development:
+- **Small Stories**: 0.5-1 day (simple enhancements, bug fixes)
+- **Medium Stories**: 1-2 days (feature additions, component development)
+- **Large Stories**: 2-3 days (complex features, integration work)
+
+## Dependency Management
+
+### Epic Dependencies
+
+```
+Epic 1 (Foundation) → Epic 2 (Components) → Epic 3 (Navigation)
+                                    ↓
+Epic 4 (Practice) ← Epic 5 (Teacher) → Epic 6 (Student)
+```
+
+### Story Dependencies
+
+- **Technical Dependencies**: Stories requiring infrastructure or components
+- **Functional Dependencies**: Stories building on previous functionality
+- **Data Dependencies**: Stories requiring specific data structures or migrations
+
+## Risk Mitigation
+
+### Epic-Level Risks
+- **Technical Complexity**: Each epic includes technical spikes for complex areas
+- **Integration Challenges**: Regular integration testing between epics
+- **Performance Impact**: Performance testing at epic completion
+
+### Story-Level Risks
+- **Uncertainty**: Technical spikes for uncertain story implementations
+- **Dependencies**: Clear identification and management of story dependencies
+- **Testing**: Comprehensive test coverage for all story implementations
+
+## Progress Tracking
+
+### Epic Completion Criteria
+- All stories completed and tested
+- Integration testing passed
+- Performance requirements met
+- Documentation updated
+- Stakeholder approval received
+
+### Story Acceptance Criteria
+- Functional requirements implemented
+- Non-functional requirements met
+- Tests written and passing
+- Code review completed
+- Documentation updated
+
+## Release Planning
+
+### Incremental Delivery
+- **Epic 1-2**: Foundation and components (Month 1-2)
+- **Epic 3-4**: Navigation and practice system (Month 2-3)
+- **Epic 5-6**: Teacher and student enhancements (Month 3-4)
+
+### Milestone Reviews
+- **Epic Reviews**: Review and approval at epic completion
+- **Sprint Reviews**: Regular progress demonstrations
+- **Stakeholder Feedback**: Continuous feedback collection and incorporation
+
+## Quality Assurance
+
+### Epic-Level Testing
+- **Integration Testing**: Cross-epic functionality testing
+- **Performance Testing**: Load and stress testing
+- **User Acceptance Testing**: Stakeholder validation
+- **Regression Testing**: Ensure existing functionality preserved
+
+### Story-Level Testing
+- **Unit Testing**: Component and function level testing
+- **Integration Testing**: Component interaction testing
+- **End-to-End Testing**: User workflow testing
+- **Accessibility Testing**: WCAG compliance validation

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -1,0 +1,21 @@
+# KA Math Companion - Brownfield PRD
+
+## Document Overview
+
+This Product Requirements Document (PRD) captures the requirements and technical specifications for enhancing the existing KA Math Companion system with new user interface improvements and functionality extensions.
+
+## Sections
+
+- [Introduction and Project Context](./introduction.md)
+- [Requirements](./requirements.md)
+- [User Interface Enhancement Goals](./ui-enhancement-goals.md)
+- [Technical Constraints and Integration Requirements](./technical-constraints.md)
+- [Epic and Story Structure](./epic-structure.md)
+- [Epic Details](./epic-details.md)
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: October 4, 2025  
+**Next Review**: November 1, 2025  
+**Stakeholders**: Development Team, Product Owner, UX Team

--- a/docs/prd/introduction.md
+++ b/docs/prd/introduction.md
@@ -1,0 +1,34 @@
+# Introduction and Project Context
+
+## Project Overview
+
+The KA Math Companion is an existing educational platform designed to enhance Khan Academy's Integrated Math 3 curriculum. This brownfield PRD outlines the requirements for significant user interface improvements and functionality enhancements to the existing system.
+
+## Current System State
+
+The existing KA Math Companion system provides:
+- Basic curriculum navigation
+- Static content presentation
+- Limited interactive elements
+- Basic progress tracking
+
+## Enhancement Objectives
+
+This enhancement initiative focuses on:
+1. Improving user experience through modern UI/UX design
+2. Adding interactive practice generators
+3. Enhancing progress tracking and visualization
+4. Integrating new assessment tools
+5. Expanding content delivery capabilities
+
+## Project Scope
+
+The enhancements will be delivered through a series of focused epics that build upon the existing foundation while maintaining backward compatibility and system stability.
+
+## Success Criteria
+
+- Improved user engagement metrics
+- Enhanced learning outcomes
+- Better teacher efficiency
+- Maintained system performance
+- Successful adoption by target users

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -1,0 +1,81 @@
+# Requirements
+
+## Functional Requirements
+
+### Core Functionality
+- **FR-001**: Enhanced curriculum navigation with improved search and filtering
+- **FR-002**: Interactive practice problem generators with immediate feedback
+- **FR-003**: Real-time progress tracking and visualization
+- **FR-004**: Teacher dashboard with class management capabilities
+- **FR-005**: Student achievement system with badges and progression
+
+### Content Management
+- **FR-006**: Dynamic content synchronization with Khan Academy
+- **FR-007**: Version control for curriculum content
+- **FR-008**: Quality assurance for practice problems
+- **FR-009**: Content customization for different learning levels
+
+### Assessment and Analytics
+- **FR-010**: Formative assessment tools with real-time feedback
+- **FR-011**: Comprehensive analytics dashboard
+- **FR-012**: Performance reporting for teachers and students
+- **FR-013**: Adaptive learning path recommendations
+
+## Non-Functional Requirements
+
+### Performance
+- **NFR-001**: Page load times under 2 seconds
+- **NFR-002**: Support for 1000+ concurrent users
+- **NFR-003**: 99.9% uptime availability
+- **NFR-004**: Response times under 500ms for API calls
+
+### Security
+- **NFR-005**: OAuth 2.0 authentication implementation
+- **NFR-006**: Data encryption for sensitive information
+- **NFR-007**: Compliance with educational privacy regulations (FERPA)
+- **NFR-008**: Regular security audits and penetration testing
+
+### Usability
+- **NFR-009**: WCAG 2.1 AA compliance for accessibility
+- **NFR-010**: Mobile-responsive design for tablets and smartphones
+- **NFR-011**: Intuitive user interface with minimal learning curve
+- **NFR-012**: Multi-language support capabilities
+
+### Reliability
+- **NFR-013**: Automated backup and recovery systems
+- **NFR-014**: Error handling and graceful degradation
+- **NFR-015**: Data integrity validation and corruption prevention
+- **NFR-016**: Comprehensive logging and monitoring
+
+## Compatibility Requirements
+
+### Browser Support
+- Chrome 90+ (recommended)
+- Firefox 88+
+- Safari 14+
+- Edge 90+
+
+### Device Compatibility
+- Desktop computers (Windows, macOS, Linux)
+- Tablets (iPad, Android tablets)
+- Smartphones (iOS 14+, Android 10+)
+
+### Integration Requirements
+- Khan Academy API compatibility
+- Learning Management System (LMS) integration
+- Single Sign-On (SSO) support for educational institutions
+- Third-party assessment tool integration
+
+## Data Requirements
+
+### Data Storage
+- Student progress data persistence
+- Teacher configuration and preferences
+- Content caching for offline access
+- Analytics data collection and storage
+
+### Data Privacy
+- Student data anonymization for analytics
+- Parental consent mechanisms for minors
+- Data retention policies compliant with educational regulations
+- Secure data transmission protocols

--- a/docs/prd/technical-constraints.md
+++ b/docs/prd/technical-constraints.md
@@ -1,0 +1,129 @@
+# Technical Constraints and Integration Requirements
+
+## System Architecture Constraints
+
+### Existing Technology Stack
+The current KA Math Companion system is built on:
+- **Frontend**: React with TypeScript
+- **Backend**: Node.js with Express
+- **Database**: PostgreSQL for structured data
+- **Caching**: Redis for session management
+- **Deployment**: Static site generation for GitHub Pages
+
+### Integration Requirements
+- **Khan Academy API**: Must maintain compatibility with existing API integration
+- **Content Synchronization**: Regular sync with Khan Academy curriculum updates
+- **Authentication System**: Preserve existing user authentication mechanisms
+- **Data Migration**: Seamless migration of existing user data
+
+## Performance Constraints
+
+### Response Time Requirements
+- **API Response Times**: Under 500ms for 95th percentile
+- **Page Load Times**: Under 2 seconds for initial page load
+- **Interactive Response**: Under 100ms for UI interactions
+- **Content Loading**: Under 3 seconds for practice problem generation
+
+### Scalability Requirements
+- **Concurrent Users**: Support for 1000+ simultaneous users
+- **Database Performance**: Handle 10,000+ queries per minute
+- **Content Delivery**: CDN integration for global performance
+- **Resource Limits**: Memory usage under 512MB per user session
+
+## Security Constraints
+
+### Authentication and Authorization
+- **OAuth 2.0**: Maintain existing OAuth implementation
+- **Role-Based Access**: Teacher, student, and admin role preservation
+- **Session Management**: Secure session handling with Redis
+- **API Security**: Rate limiting and input validation
+
+### Data Protection
+- **FERPA Compliance**: Educational data privacy requirements
+- **Data Encryption**: Encryption for sensitive data at rest and in transit
+- **Audit Logging**: Comprehensive logging for security monitoring
+- **Backup Security**: Encrypted backups with secure storage
+
+## Browser and Device Constraints
+
+### Supported Browsers
+- **Modern Browsers**: Chrome 90+, Firefox 88+, Safari 14+, Edge 90+
+- **Mobile Support**: iOS Safari 14+, Chrome Mobile 90+
+- **Progressive Enhancement**: Core functionality on older browsers
+- **Feature Detection**: Graceful degradation for unsupported features
+
+### Device Limitations
+- **Touch Interface**: Support for touch-based interactions
+- **Screen Sizes**: Responsive design from 320px to 4K displays
+- **Performance**: Optimization for lower-end devices
+- **Offline Capability**: Limited offline functionality with service workers
+
+## Content Management Constraints
+
+### Khan Academy Integration
+- **API Rate Limits**: Respect Khan Academy API usage limits
+- **Content Licensing**: Maintain compliance with Khan Academy content terms
+- **Update Frequency**: Handle curriculum updates without service disruption
+- **Content Validation**: Ensure accuracy of synchronized content
+
+### Content Delivery
+- **Static Site Generation**: Maintain GitHub Pages deployment compatibility
+- **CDN Integration**: Use CDN for static asset delivery
+- **Caching Strategy**: Intelligent caching for content and API responses
+- **Version Control**: Track content versions and changes
+
+## Development and Deployment Constraints
+
+### Development Environment
+- **TypeScript**: Maintain type safety across the codebase
+- **Testing**: Comprehensive test coverage for new features
+- **Code Quality**: ESLint and Prettier for code consistency
+- **Documentation**: Maintain API documentation and component docs
+
+### Deployment Pipeline
+- **CI/CD**: Automated testing and deployment
+- **Rollback Strategy**: Ability to quickly rollback problematic releases
+- **Feature Flags**: Toggle features for gradual rollout
+- **Monitoring**: Application performance and error monitoring
+
+## Third-Party Dependencies
+
+### External Services
+- **Khan Academy API**: Critical dependency for content
+- **Authentication Providers**: OAuth providers for user login
+- **Analytics Services**: User behavior and performance analytics
+- **Error Tracking**: Error reporting and debugging services
+
+### Library Constraints
+- **React Ecosystem**: Maintain compatibility with React ecosystem
+- **Bundle Size**: Keep JavaScript bundle size under 2MB
+- **Tree Shaking**: Eliminate unused code from production builds
+- **Security Updates**: Regular updates for security vulnerabilities
+
+## Regulatory and Compliance Constraints
+
+### Educational Regulations
+- **COPPA**: Children's Online Privacy Protection Act compliance
+- **FERPA**: Family Educational Rights and Privacy Act
+- **Accessibility**: WCAG 2.1 AA compliance requirements
+- **Data Retention**: Educational data retention policies
+
+### International Considerations
+- **GDPR**: General Data Protection Regulation for international users
+- **Language Support**: Multi-language capability requirements
+- **Cultural Sensitivity**: Content appropriate for diverse audiences
+- **Time Zones**: Handle time zone differences for global users
+
+## Technical Debt and Legacy Constraints
+
+### Existing Code Limitations
+- **Legacy Components**: Maintain compatibility with existing components
+- **Database Schema**: Work within existing database structure
+- **API Contracts**: Preserve existing API endpoint contracts
+- **Migration Strategy**: Gradual migration of legacy functionality
+
+### Refactoring Constraints
+- **Backward Compatibility**: Maintain existing functionality during refactoring
+- **Data Migration**: Safe migration of existing user data
+- **Testing Requirements**: Comprehensive testing for refactored components
+- **Documentation**: Update documentation for changed functionality

--- a/docs/prd/ui-enhancement-goals.md
+++ b/docs/prd/ui-enhancement-goals.md
@@ -1,0 +1,93 @@
+# User Interface Enhancement Goals
+
+## Design Philosophy
+
+The UI enhancements will follow a modern, clean design philosophy focused on:
+- **Clarity**: Information hierarchy that guides user attention
+- **Efficiency**: Minimal clicks to achieve common tasks
+- **Engagement**: Interactive elements that maintain user interest
+- **Accessibility**: Inclusive design for all users
+
+## Visual Design Improvements
+
+### Modern Aesthetics
+- **Color Scheme**: Updated color palette with better contrast ratios
+- **Typography**: Improved font hierarchy and readability
+- **Spacing**: Consistent spacing system for better visual rhythm
+- **Icons**: Modern icon set for intuitive navigation
+
+### Responsive Design
+- **Mobile-First Approach**: Design for mobile devices first, then scale up
+- **Flexible Layouts**: Grid-based layouts that adapt to screen sizes
+- **Touch-Friendly**: Larger touch targets and gesture support
+- **Progressive Enhancement**: Core functionality available on all devices
+
+## Interaction Design
+
+### Navigation Improvements
+- **Simplified Menu Structure**: Reduced cognitive load in navigation
+- **Breadcrumb Navigation**: Clear path indication for deep content
+- **Search Functionality**: Powerful search with filters and suggestions
+- **Quick Actions**: Frequently used actions accessible from anywhere
+
+### Interactive Elements
+- **Micro-interactions**: Subtle animations for user feedback
+- **Loading States**: Clear indication of system processing
+- **Error Handling**: User-friendly error messages and recovery options
+- **Success Feedback**: Positive reinforcement for completed actions
+
+## User Experience Enhancements
+
+### Teacher Experience
+- **Dashboard Redesign**: At-a-glance view of class progress
+- **Lesson Planning Tools**: Streamlined lesson preparation workflow
+- **Assessment Creation**: Easy-to-use assessment builder
+- **Communication Tools**: Integrated messaging with students
+
+### Student Experience
+- **Gamification Elements**: Points, badges, and progression systems
+- **Personalized Learning Paths**: Adaptive content recommendations
+- **Social Features**: Collaborative learning opportunities
+- **Progress Visualization**: Clear representation of learning achievements
+
+## Accessibility Improvements
+
+### Visual Accessibility
+- **High Contrast Modes**: Options for users with visual impairments
+- **Text Scaling**: Support for larger text sizes without layout breakage
+- **Color Blindness Support**: Design choices that work for all color vision types
+- **Screen Reader Compatibility**: Proper ARIA labels and semantic HTML
+
+### Motor Accessibility
+- **Keyboard Navigation**: Full functionality available via keyboard
+- **Voice Control**: Support for voice commands where appropriate
+- **Reduced Motion**: Options for users sensitive to motion
+- **Touch Alternatives**: Multiple ways to interact with elements
+
+## Performance Optimization
+
+### Loading Performance
+- **Lazy Loading**: Load content as needed rather than all at once
+- **Image Optimization**: Compressed images with responsive loading
+- **Code Splitting**: Load only necessary JavaScript for each page
+- **Caching Strategy**: Intelligent caching of frequently used resources
+
+### Interaction Performance
+- **Smooth Animations**: 60fps animations for better user experience
+- **Instant Feedback**: Immediate response to user actions
+- **Background Processing**: Non-blocking operations for long tasks
+- **Optimized Rendering**: Efficient DOM manipulation and updates
+
+## Technical Implementation
+
+### Component Library
+- **Design System**: Consistent component library with documentation
+- **Reusable Components**: Modular components for maintainability
+- **Theme System**: Customizable themes for different user preferences
+- **Component Testing**: Automated testing for UI components
+
+### Frontend Architecture
+- **Modern Framework**: React with TypeScript for type safety
+- **State Management**: Efficient state management for complex interactions
+- **Routing**: Client-side routing for fast navigation
+- **API Integration**: Optimized data fetching and caching strategies

--- a/lib/getCurriculum.test.ts
+++ b/lib/getCurriculum.test.ts
@@ -1,5 +1,4 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_CURRICULUM_SLUG,
@@ -9,35 +8,36 @@ import {
 } from "./getCurriculum";
 import document from "../docs/data/integrated-math-3.course.json" assert { type: "json" };
 
-test("getCurriculum returns course metadata with units and lessons", () => {
-  const course = getCurriculum();
-  assert.equal(course.slug, "math3");
-  assert.ok(course.units.length > 0);
-  const firstUnit = course.units[0];
-  assert.ok(firstUnit.lessons.length > 0);
+describe("getCurriculum", () => {
+  it("returns course metadata with units and lessons", () => {
+    const course = getCurriculum();
+    expect(course.slug).toBe("math3");
+    expect(course.units.length).toBeGreaterThan(0);
+    const firstUnit = course.units[0];
+    expect(firstUnit.lessons.length).toBeGreaterThan(0);
+  });
+
+  it("accepts an explicit curriculum slug", () => {
+    const course = getCurriculum(DEFAULT_CURRICULUM_SLUG);
+    expect(course.title).toBe("Integrated math 3");
+  });
 });
 
-test("getCurriculum accepts an explicit curriculum slug", () => {
-  const course = getCurriculum(DEFAULT_CURRICULUM_SLUG);
-  assert.equal(course.title, "Integrated math 3");
+describe("listCurricula", () => {
+  it("includes the default curriculum entry", () => {
+    const curricula = listCurricula();
+    const math3 = curricula.find((entry) => entry.slug === DEFAULT_CURRICULUM_SLUG);
+    expect(math3).toBeDefined();
+    expect(math3?.title).toBe("Integrated math 3");
+  });
 });
 
-test("listCurricula includes the default curriculum entry", () => {
-  const curricula = listCurricula();
-  const math3 = curricula.find((entry) => entry.slug === DEFAULT_CURRICULUM_SLUG);
-  assert.ok(math3, "integrated math 3 curriculum should be registered");
-  assert.equal(math3?.title, "Integrated math 3");
-});
+describe("parseCurriculumDocument", () => {
+  it("throws when course units are missing", () => {
+    const malformed = structuredClone(document);
+    // @ts-expect-error mutating for test coverage
+    delete malformed.course.units;
 
-test("parseCurriculumDocument throws when course units are missing", () => {
-  const malformed = structuredClone(document);
-  // @ts-expect-error mutating for test coverage
-  delete malformed.course.units;
-
-  assert.throws(
-    () => {
-      parseCurriculumDocument(malformed);
-    },
-    /course\.units/
-  );
+    expect(() => parseCurriculumDocument(malformed)).toThrow(/course\.units/);
+  });
 });

--- a/lib/progress-tracker.test.ts
+++ b/lib/progress-tracker.test.ts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { beforeEach, describe, expect, it } from "vitest";
 import { ProgressTracker, type LessonProgress } from "./progress-tracker";
 
 // Mock localStorage and window object
@@ -24,127 +23,122 @@ Object.defineProperty(global, 'window', {
   writable: true,
 });
 
-test("ProgressTracker creates default progress for new lesson", () => {
-  const lessonId = "test-lesson-1";
-  const progress = ProgressTracker.getLessonProgress(lessonId);
-  
-  assert.equal(progress.lessonId, lessonId);
-  assert.equal(progress.attempts, 0);
-  assert.equal(progress.correctAttempts, 0);
-  assert.equal(progress.lastAttemptDate, null);
-  assert.equal(progress.masteryLevel, "not-started");
-  assert.equal(progress.hintsUsed, 0);
-  assert.equal(progress.spacedPracticeStreak, 0);
-});
-
-test("ProgressTracker updates lesson progress", () => {
-  const lessonId = "test-lesson-2";
-  
-  const updated = ProgressTracker.updateLessonProgress(lessonId, {
-    attempts: 10,
-    correctAttempts: 8,
-    hintsUsed: 2,
+describe("ProgressTracker", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    ProgressTracker.clearProgress();
   });
-  
-  assert.equal(updated.attempts, 10);
-  assert.equal(updated.correctAttempts, 8);
-  assert.equal(updated.hintsUsed, 2);
-  assert.equal(updated.masteryLevel, "mastered");
-  assert.ok(updated.lastAttemptDate);
-});
 
-test("ProgressTracker calculates mastery levels correctly", () => {
-  const testCases: Array<{
-    attempts: number;
-    correct: number;
-    hints: number;
-    spacedPracticeStreak?: number;
-    expected: LessonProgress['masteryLevel'];
-  }> = [
-    { attempts: 0, correct: 0, hints: 0, expected: "not-started" },
-    { attempts: 10, correct: 3, hints: 0, expected: "struggling" },
-    { attempts: 10, correct: 6, hints: 0, expected: "progressing" },
-    { attempts: 10, correct: 8, hints: 1, expected: "mastered" },
-    { attempts: 10, correct: 9, hints: 0, spacedPracticeStreak: 3, expected: "overlearned" },
-  ];
-  
-  testCases.forEach(({ attempts, correct, hints, spacedPracticeStreak = 0, expected }) => {
-    const lessonId = `test-${attempts}-${correct}`;
-    const progress = ProgressTracker.updateLessonProgress(lessonId, {
-      attempts,
-      correctAttempts: correct,
-      hintsUsed: hints,
-      spacedPracticeStreak,
+  it("creates default progress for new lesson", () => {
+    const lessonId = "test-lesson-1";
+    const progress = ProgressTracker.getLessonProgress(lessonId);
+
+    expect(progress.lessonId).toBe(lessonId);
+    expect(progress.attempts).toBe(0);
+    expect(progress.correctAttempts).toBe(0);
+    expect(progress.lastAttemptDate).toBeNull();
+    expect(progress.masteryLevel).toBe("not-started");
+    expect(progress.hintsUsed).toBe(0);
+    expect(progress.spacedPracticeStreak).toBe(0);
+  });
+
+  it("updates lesson progress", () => {
+    const lessonId = "test-lesson-2";
+
+    const updated = ProgressTracker.updateLessonProgress(lessonId, {
+      attempts: 10,
+      correctAttempts: 8,
+      hintsUsed: 2,
     });
-    
-    assert.equal(progress.masteryLevel, expected, 
-      `Expected ${expected} for ${correct}/${attempts} correct with ${hints} hints`);
-  });
-});
 
-test("ProgressTracker persists progress to localStorage", () => {
-  const lessonId = "test-lesson-persist";
-  
-  // Clear any existing data
-  mockLocalStorage.clear();
-  ProgressTracker.clearProgress();
-  
-  ProgressTracker.updateLessonProgress(lessonId, {
-    attempts: 5,
-    correctAttempts: 4,
+    expect(updated.attempts).toBe(10);
+    expect(updated.correctAttempts).toBe(8);
+    expect(updated.hintsUsed).toBe(2);
+    expect(updated.masteryLevel).toBe("mastered");
+    expect(updated.lastAttemptDate).toBeTruthy();
   });
-  
-  // Verify it was stored
-  const stored = mockLocalStorage.get('ka:progress:v1');
-  assert.ok(stored, "progress should be stored in localStorage");
-  
-  // Clear in-memory state but keep localStorage
-  const storedData = stored;
-  mockLocalStorage.clear();
-  mockLocalStorage.set('ka:progress:v1', storedData);
-  
-  // Force ProgressTracker to read from localStorage by clearing any internal cache
-  ProgressTracker._clearCache();
-  
-  // Retrieve progress again
-  const retrieved = ProgressTracker.getLessonProgress(lessonId);
-  
-  assert.equal(retrieved.attempts, 5);
-  assert.equal(retrieved.correctAttempts, 4);
-});
 
-test("ProgressTracker exports and imports progress", () => {
-  const lessonId = "test-lesson-export";
-  
-  // Clear any existing data
-  mockLocalStorage.clear();
-  ProgressTracker.clearProgress();
-  
-  const updated = ProgressTracker.updateLessonProgress(lessonId, {
-    attempts: 3,
-    correctAttempts: 2,
+  it("calculates mastery levels correctly", () => {
+    const testCases: Array<{
+      attempts: number;
+      correct: number;
+      hints: number;
+      spacedPracticeStreak?: number;
+      expected: LessonProgress['masteryLevel'];
+    }> = [
+      { attempts: 0, correct: 0, hints: 0, expected: "not-started" },
+      { attempts: 10, correct: 3, hints: 0, expected: "struggling" },
+      { attempts: 10, correct: 6, hints: 0, expected: "progressing" },
+      { attempts: 10, correct: 8, hints: 1, expected: "mastered" },
+      { attempts: 10, correct: 9, hints: 0, spacedPracticeStreak: 3, expected: "overlearned" },
+    ];
+
+    testCases.forEach(({ attempts, correct, hints, spacedPracticeStreak = 0, expected }) => {
+      const lessonId = `test-${attempts}-${correct}`;
+      const progress = ProgressTracker.updateLessonProgress(lessonId, {
+        attempts,
+        correctAttempts: correct,
+        hintsUsed: hints,
+        spacedPracticeStreak,
+      });
+
+      expect(progress.masteryLevel).toBe(expected);
+    });
   });
-  
-  assert.ok(updated, "update should return progress");
-  
-  const exported = ProgressTracker.exportProgress();
-  assert.ok(exported.includes(lessonId));
-  
-  // Clear and import
-  ProgressTracker.clearProgress();
-  const importSuccess = ProgressTracker.importProgress(exported);
-  
-  assert.ok(importSuccess);
-  
-  const retrieved = ProgressTracker.getLessonProgress(lessonId);
-  assert.equal(retrieved.attempts, 3);
-  assert.equal(retrieved.correctAttempts, 2);
-});
 
-test("ProgressTracker handles invalid import data", () => {
-  const importSuccess = ProgressTracker.importProgress("invalid json");
-  assert.equal(importSuccess, false);
-  
-  const importSuccess2 = ProgressTracker.importProgress('{"invalid": "structure"}');
-  assert.equal(importSuccess2, false);
+  it("persists progress to localStorage", () => {
+    const lessonId = "test-lesson-persist";
+
+    ProgressTracker.updateLessonProgress(lessonId, {
+      attempts: 5,
+      correctAttempts: 4,
+    });
+
+    const stored = mockLocalStorage.get('ka:progress:v1');
+    expect(stored).toBeTruthy();
+
+    const storedData = stored;
+    mockLocalStorage.clear();
+    if (storedData) {
+      mockLocalStorage.set('ka:progress:v1', storedData);
+    }
+
+    ProgressTracker._clearCache();
+
+    const retrieved = ProgressTracker.getLessonProgress(lessonId);
+
+    expect(retrieved.attempts).toBe(5);
+    expect(retrieved.correctAttempts).toBe(4);
+  });
+
+  it("exports and imports progress", () => {
+    const lessonId = "test-lesson-export";
+
+    const updated = ProgressTracker.updateLessonProgress(lessonId, {
+      attempts: 3,
+      correctAttempts: 2,
+    });
+
+    expect(updated).toBeTruthy();
+
+    const exported = ProgressTracker.exportProgress();
+    expect(exported.includes(lessonId)).toBe(true);
+
+    ProgressTracker.clearProgress();
+    const importSuccess = ProgressTracker.importProgress(exported);
+
+    expect(importSuccess).toBe(true);
+
+    const retrieved = ProgressTracker.getLessonProgress(lessonId);
+    expect(retrieved.attempts).toBe(3);
+    expect(retrieved.correctAttempts).toBe(2);
+  });
+
+  it("handles invalid import data", () => {
+    const importSuccess = ProgressTracker.importProgress("invalid json");
+    expect(importSuccess).toBe(false);
+
+    const importSuccess2 = ProgressTracker.importProgress('{"invalid": "structure"}');
+    expect(importSuccess2).toBe(false);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint --max-warnings=0 .",
-    "test": "tsx --test \"**/*.test.ts\" \"**/*.test.tsx\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "sync:khan:math3": "node docs/scripts/sync-khan-course.mjs --path /math/math3 --slug integrated-math-3",
     "bmad:refresh": "bmad-method install -f -i codex",
     "bmad:list": "bmad-method list:agents",
@@ -28,11 +31,16 @@
     "@types/node": "^22.12.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "@typescript-eslint/eslint-plugin": "^8.18.2",
+    "@typescript-eslint/parser": "^8.18.2",
     "eslint": "8.57.1",
     "eslint-config-next": "15.5.3",
+    "eslint-plugin-mdx": "^3.1.4",
     "jsdom": "^27.0.0",
+    "prettier": "^3.4.2",
     "tsx": "^4.20.5",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
   },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,21 +34,36 @@ devDependencies:
   '@types/react-dom':
     specifier: ^19.1.9
     version: 19.1.9(@types/react@19.1.13)
+  '@typescript-eslint/eslint-plugin':
+    specifier: ^8.18.2
+    version: 8.44.1(@typescript-eslint/parser@8.44.1)(eslint@8.57.1)(typescript@5.9.2)
+  '@typescript-eslint/parser':
+    specifier: ^8.18.2
+    version: 8.44.1(eslint@8.57.1)(typescript@5.9.2)
   eslint:
     specifier: 8.57.1
     version: 8.57.1
   eslint-config-next:
     specifier: 15.5.3
     version: 15.5.3(eslint@8.57.1)(typescript@5.9.2)
+  eslint-plugin-mdx:
+    specifier: ^3.1.4
+    version: 3.6.2(eslint@8.57.1)
   jsdom:
     specifier: ^27.0.0
     version: 27.0.0(postcss@8.4.31)
+  prettier:
+    specifier: ^3.4.2
+    version: 3.6.2
   tsx:
     specifier: ^4.20.5
     version: 4.20.5
   typescript:
     specifier: ^5.6.3
     version: 5.9.2
+  vitest:
+    specifier: ^2.1.4
+    version: 2.1.9(@types/node@22.18.6)(jsdom@27.0.0)
 
 packages:
 
@@ -74,6 +89,20 @@ packages:
 
   /@asamuzakjp/nwsapi@2.3.9:
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+    dev: true
+
+  /@babel/code-frame@7.27.1:
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+    dev: true
+
+  /@babel/helper-validator-identifier@7.27.1:
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
     dev: true
 
   /@bhavjit/khan-api@0.7.4:
@@ -161,6 +190,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/aix-ppc64@0.25.10:
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
@@ -170,10 +208,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.25.10:
     resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
@@ -188,6 +244,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.25.10:
     resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
     engines: {node: '>=18'}
@@ -197,10 +262,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.25.10:
     resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -215,10 +298,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.25.10:
     resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
@@ -233,10 +334,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64@0.25.10:
     resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -251,10 +370,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.25.10:
     resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -269,10 +406,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.25.10:
     resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -287,6 +442,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.25.10:
     resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
@@ -296,10 +460,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.25.10:
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -323,6 +505,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.25.10:
     resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
@@ -336,6 +527,15 @@ packages:
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
     requiresBuild: true
     dev: true
@@ -359,11 +559,29 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.25.10:
     resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
     requiresBuild: true
     dev: true
     optional: true
@@ -377,10 +595,28 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.25.10:
     resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -669,6 +905,22 @@ packages:
     dev: false
     optional: true
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
   /@mdx-js/react@3.1.1(@types/react@19.1.13)(react@19.1.1):
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
@@ -813,6 +1065,264 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
+  /@npmcli/config@8.3.4:
+    resolution: {integrity: sha512-01rtHedemDNhUXdicU7s+QYz/3JyV5Naj84cvdXGH4mgCdL+agmSYaLF4LUG4vMCLzhBO8YtS0gPpH1FGvbgAw==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/map-workspaces': 3.0.6
+      '@npmcli/package-json': 5.2.1
+      ci-info: 4.3.0
+      ini: 4.1.3
+      nopt: 7.2.1
+      proc-log: 4.2.0
+      semver: 7.7.2
+      walk-up-path: 3.0.1
+    transitivePeerDependencies:
+      - bluebird
+    dev: true
+
+  /@npmcli/git@5.0.8:
+    resolution: {integrity: sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/promise-spawn': 7.0.2
+      ini: 4.1.3
+      lru-cache: 10.4.3
+      npm-pick-manifest: 9.1.0
+      proc-log: 4.2.0
+      promise-inflight: 1.0.1
+      promise-retry: 2.0.1
+      semver: 7.7.2
+      which: 4.0.0
+    transitivePeerDependencies:
+      - bluebird
+    dev: true
+
+  /@npmcli/map-workspaces@3.0.6:
+    resolution: {integrity: sha512-tkYs0OYnzQm6iIRdfy+LcLBjcKuQCeE5YLb8KnrIlutJfheNaPvPpgoFEyEFgbjzl5PLZ3IA/BWAwRU0eHuQDA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/name-from-folder': 2.0.0
+      glob: 10.4.5
+      minimatch: 9.0.5
+      read-package-json-fast: 3.0.2
+    dev: true
+
+  /@npmcli/name-from-folder@2.0.0:
+    resolution: {integrity: sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
+  /@npmcli/package-json@5.2.1:
+    resolution: {integrity: sha512-f7zYC6kQautXHvNbLEWgD/uGu1+xCn9izgqBfgItWSx22U0ZDekxN08A1vM8cTxj/cRVe0Q94Ode+tdoYmIOOQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/git': 5.0.8
+      glob: 10.4.5
+      hosted-git-info: 7.0.2
+      json-parse-even-better-errors: 3.0.2
+      normalize-package-data: 6.0.2
+      proc-log: 4.2.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - bluebird
+    dev: true
+
+  /@npmcli/promise-spawn@7.0.2:
+    resolution: {integrity: sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      which: 4.0.0
+    dev: true
+
+  /@pkgjs/parseargs@0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@pkgr/core@0.2.9:
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.52.4:
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.52.4:
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.52.4:
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.52.4:
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.52.4:
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.52.4:
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.52.4:
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.52.4:
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.52.4:
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.52.4:
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.52.4:
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.52.4:
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.52.4:
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.52.4:
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.52.4:
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.52.4:
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.52.4:
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.52.4:
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.52.4:
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.52.4:
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.52.4:
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.52.4:
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
@@ -835,13 +1345,55 @@ packages:
     dev: true
     optional: true
 
+  /@types/concat-stream@2.0.3:
+    resolution: {integrity: sha512-3qe4oQAPNwVNwK4C9c8u+VJqv9kez+2MR4qJpoPFfXtgxxif1QbFusvXzK0/Wra2VX07smostI2VMmJNSpZjuQ==}
+    dependencies:
+      '@types/node': 22.18.6
+    dev: true
+
+  /@types/debug@4.1.12:
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+    dependencies:
+      '@types/ms': 2.1.0
+    dev: true
+
+  /@types/estree-jsx@1.0.5:
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
+  /@types/estree@1.0.8:
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: true
+
+  /@types/hast@3.0.4:
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: true
+
+  /@types/is-empty@1.2.3:
+    resolution: {integrity: sha512-4J1l5d79hoIvsrKh5VUKVRA1aIdsOb10Hu5j3J2VfP/msDnfTdGPmNp2E1Wg+vs97Bktzo+MZePFFXSGoykYJw==}
+    dev: true
+
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/mdast@4.0.4:
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+    dependencies:
+      '@types/unist': 3.0.3
     dev: true
 
   /@types/mdx@2.0.13:
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
     dev: false
+
+  /@types/ms@2.1.0:
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+    dev: true
 
   /@types/node@22.18.6:
     resolution: {integrity: sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==}
@@ -861,6 +1413,18 @@ packages:
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
     dependencies:
       csstype: 3.1.3
+
+  /@types/supports-color@8.1.3:
+    resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
+    dev: true
+
+  /@types/unist@2.0.11:
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+    dev: true
+
+  /@types/unist@3.0.3:
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+    dev: true
 
   /@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1)(eslint@8.57.1)(typescript@5.9.2):
     resolution: {integrity: sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==}
@@ -1162,6 +1726,72 @@ packages:
     dev: true
     optional: true
 
+  /@vitest/expect@2.1.9:
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+    dev: true
+
+  /@vitest/mocker@2.1.9(vite@5.4.20):
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+      vite: 5.4.20(@types/node@22.18.6)
+    dev: true
+
+  /@vitest/pretty-format@2.1.9:
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+    dependencies:
+      tinyrainbow: 1.2.0
+    dev: true
+
+  /@vitest/runner@2.1.9:
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@2.1.9:
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.19
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/spy@2.1.9:
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+    dependencies:
+      tinyspy: 3.0.2
+    dev: true
+
+  /@vitest/utils@2.1.9:
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+    dev: true
+
+  /abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1195,11 +1825,21 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+    dev: true
+
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
     dev: true
 
   /argparse@2.0.1:
@@ -1302,6 +1942,11 @@ packages:
       is-array-buffer: 3.0.5
     dev: true
 
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
     dev: true
@@ -1326,6 +1971,10 @@ packages:
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
     dev: true
 
   /balanced-match@1.0.2:
@@ -1356,6 +2005,15 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
+    dev: true
+
+  /buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /call-bind-apply-helpers@1.0.2:
@@ -1393,12 +2051,53 @@ packages:
     resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
     dev: false
 
+  /ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    dev: true
+
+  /chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+    dev: true
+
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
+
+  /character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+    dev: true
+
+  /character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+    dev: true
+
+  /character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: true
+
+  /character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    dev: true
+
+  /check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+    dev: true
+
+  /ci-info@4.3.0:
+    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /client-only@0.0.1:
@@ -1418,6 +2117,16 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
+  /concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
     dev: true
 
   /cross-fetch@4.1.0:
@@ -1525,6 +2234,17 @@ packages:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
     dev: true
 
+  /decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: true
+
+  /deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -1547,12 +2267,28 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
     requiresBuild: true
     dev: false
     optional: true
+
+  /devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
+  /diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1577,6 +2313,18 @@ packages:
       gopd: 1.2.0
     dev: true
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
+  /emoji-regex@10.5.0:
+    resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
@@ -1584,6 +2332,16 @@ packages:
   /entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+    dev: true
+
+  /err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+    dev: true
+
+  /error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+    dependencies:
+      is-arrayish: 0.2.1
     dev: true
 
   /es-abstract@1.24.0:
@@ -1678,6 +2436,10 @@ packages:
       safe-array-concat: 1.1.3
     dev: true
 
+  /es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+    dev: true
+
   /es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1709,6 +2471,37 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+    dev: true
+
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
     dev: true
 
   /esbuild@0.25.10:
@@ -1813,6 +2606,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-mdx@3.6.2(eslint@8.57.1):
+    resolution: {integrity: sha512-5hczn5iSSEcwtNtVXFwCKIk6iLEDaZpwc3vjYDl/B779OzaAAK/ou16J2xVdO6ecOLEO1WZqp7MRCQ/WsKDUig==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+      remark-lint-file-extension: '*'
+    peerDependenciesMeta:
+      remark-lint-file-extension:
+        optional: true
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint: 8.57.1
+      espree: 9.6.1
+      estree-util-visit: 2.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      synckit: 0.11.11
+      unified: 11.0.5
+      unified-engine: 11.2.2
+      unist-util-visit: 5.0.0
+      uvu: 0.5.6
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    dev: true
+
   /eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
     engines: {node: '>=4'}
@@ -1902,6 +2724,29 @@ packages:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+    dev: true
+
+  /eslint-plugin-mdx@3.6.2(eslint@8.57.1):
+    resolution: {integrity: sha512-RfMd5HYD/9+cqANhVWJbuBRg3huWUsAoGJNGmPsyiRD2X6BaG6bvt1omyk1ORlg81GK8ST7Ojt5fNAuwWhWU8A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+    dependencies:
+      eslint: 8.57.1
+      eslint-mdx: 3.6.2(eslint@8.57.1)
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      synckit: 0.11.11
+      unified: 11.0.5
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - bluebird
+      - remark-lint-file-extension
+      - supports-color
     dev: true
 
   /eslint-plugin-react-hooks@5.2.0(eslint@8.57.1):
@@ -2034,9 +2879,35 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+    dev: true
+
+  /estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: true
 
   /fast-deep-equal@3.1.3:
@@ -2133,6 +3004,14 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -2218,6 +3097,18 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+    dev: true
+
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -2296,6 +3187,13 @@ packages:
       function-bind: 1.1.2
     dev: true
 
+  /hosted-git-info@7.0.2:
+    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      lru-cache: 10.4.3
+    dev: true
+
   /html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -2335,6 +3233,11 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /ignore@6.0.2:
+    resolution: {integrity: sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==}
+    engines: {node: '>= 4'}
+    dev: true
+
   /ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
@@ -2346,6 +3249,10 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
+
+  /import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
     dev: true
 
   /imurmurhash@0.1.4:
@@ -2365,6 +3272,11 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
+  /ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
   /internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -2374,6 +3286,17 @@ packages:
       side-channel: 1.1.0
     dev: true
 
+  /is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+    dev: true
+
+  /is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+    dev: true
+
   /is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2381,6 +3304,10 @@ packages:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+    dev: true
+
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: true
 
   /is-async-function@2.1.1:
@@ -2444,6 +3371,14 @@ packages:
       has-tostringtag: 1.0.2
     dev: true
 
+  /is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+    dev: true
+
+  /is-empty@1.2.0:
+    resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2454,6 +3389,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bound: 1.0.4
+    dev: true
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-generator-function@1.1.0:
@@ -2471,6 +3411,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+    dev: true
+
+  /is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
     dev: true
 
   /is-map@2.0.3:
@@ -2499,6 +3443,11 @@ packages:
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-potential-custom-element-name@1.0.1:
@@ -2579,6 +3528,11 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+    dev: true
+
   /iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2589,6 +3543,14 @@ packages:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+    dev: true
+
+  /jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
     dev: true
 
   /js-tokens@4.0.0:
@@ -2642,6 +3604,11 @@ packages:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
     dev: true
 
+  /json-parse-even-better-errors@3.0.2:
+    resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
@@ -2673,6 +3640,11 @@ packages:
       json-buffer: 3.0.1
     dev: true
 
+  /kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
     dev: true
@@ -2692,6 +3664,20 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /lines-and-columns@2.0.4:
+    resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /load-plugin@6.0.3:
+    resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
+    dependencies:
+      '@npmcli/config': 8.3.4
+      import-meta-resolve: 4.2.0
+    transitivePeerDependencies:
+      - bluebird
+    dev: true
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2703,6 +3689,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    dev: true
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2710,14 +3700,131 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+    dev: true
+
+  /lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    dev: true
+
   /lru-cache@11.2.1:
     resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
     engines: {node: 20 || >=22}
     dev: true
 
+  /magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+    dev: true
+
+  /mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+    dev: true
+
+  /mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+    dependencies:
+      '@types/mdast': 4.0.4
     dev: true
 
   /mdn-data@2.12.2:
@@ -2727,6 +3834,268 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+    dev: true
+
+  /micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+    dependencies:
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+    dev: true
+
+  /micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+    dev: true
+
+  /micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+    dependencies:
+      micromark-util-symbol: 2.0.1
+    dev: true
+
+  /micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+    dependencies:
+      micromark-util-symbol: 2.0.1
+    dev: true
+
+  /micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+    dev: true
+
+  /micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+    dev: true
+
+  /micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+    dev: true
+
+  /micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+    dev: true
+
+  /micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+    dependencies:
+      micromark-util-symbol: 2.0.1
+    dev: true
+
+  /micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+    dependencies:
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+    dev: true
+
+  /micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: true
+
+  /micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+    dev: true
+
+  /micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+    dev: true
+
+  /micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /micromatch@4.0.8:
@@ -2752,6 +4121,16 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
+
+  /minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
+  /mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
     dev: true
 
   /ms@2.1.3:
@@ -2827,6 +4206,55 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: false
+
+  /nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      abbrev: 2.0.0
+    dev: true
+
+  /normalize-package-data@6.0.2:
+    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      hosted-git-info: 7.0.2
+      semver: 7.7.2
+      validate-npm-package-license: 3.0.4
+    dev: true
+
+  /npm-install-checks@6.3.0:
+    resolution: {integrity: sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      semver: 7.7.2
+    dev: true
+
+  /npm-normalize-package-bin@3.0.1:
+    resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
+  /npm-package-arg@11.0.3:
+    resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      hosted-git-info: 7.0.2
+      proc-log: 4.2.0
+      semver: 7.7.2
+      validate-npm-package-name: 5.0.1
+    dev: true
+
+  /npm-pick-manifest@9.1.0:
+    resolution: {integrity: sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      npm-install-checks: 6.3.0
+      npm-normalize-package-bin: 3.0.1
+      npm-package-arg: 11.0.3
+      semver: 7.7.2
+    dev: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2935,11 +4363,38 @@ packages:
       p-limit: 3.1.0
     dev: true
 
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    dev: true
+
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+    dev: true
+
+  /parse-json@7.1.1:
+    resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 3.0.2
+      lines-and-columns: 2.0.4
+      type-fest: 3.13.1
     dev: true
 
   /parse5@7.3.0:
@@ -2965,6 +4420,23 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+    dev: true
+
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
+  /pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
     dev: true
 
   /picocolors@1.1.1:
@@ -2993,9 +4465,46 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  /postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
+  /proc-log@4.2.0:
+    resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
+  /promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dev: true
+
+  /promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
     dev: true
 
   /prop-types@15.8.1:
@@ -3033,6 +4542,23 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /read-package-json-fast@3.0.2:
+    resolution: {integrity: sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      json-parse-even-better-errors: 3.0.2
+      npm-normalize-package-bin: 3.0.1
+    dev: true
+
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3057,6 +4583,34 @@ packages:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+    dev: true
+
+  /remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
     dev: true
 
   /require-from-string@2.0.2:
@@ -3092,6 +4646,11 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+    dev: true
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3105,6 +4664,38 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
+      fsevents: 2.3.3
+    dev: true
+
   /rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
     dev: true
@@ -3113,6 +4704,13 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
+
+  /sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
     dev: true
 
   /safe-array-concat@1.1.3:
@@ -3124,6 +4722,10 @@ packages:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+    dev: true
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: true
 
   /safe-push-apply@1.0.0:
@@ -3285,6 +4887,15 @@ packages:
       side-channel-weakmap: 1.0.2
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3294,8 +4905,38 @@ packages:
     engines: {node: '>= 12'}
     dev: false
 
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.22
+    dev: true
+
+  /spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+    dev: true
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.22
+    dev: true
+
+  /spdx-license-ids@3.0.22:
+    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+    dev: true
+
   /stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
     dev: true
 
   /stop-iteration-iterator@1.1.0:
@@ -3304,6 +4945,33 @@ packages:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+    dev: true
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+    dev: true
+
+  /string-width@6.1.0:
+    resolution: {integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 10.5.0
+      strip-ansi: 7.1.2
     dev: true
 
   /string.prototype.includes@2.0.1:
@@ -3373,11 +5041,31 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+    dev: true
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+    dev: true
+
+  /strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.2.2
     dev: true
 
   /strip-bom@3.0.0:
@@ -3414,6 +5102,11 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3423,8 +5116,23 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
 
+  /synckit@0.11.11:
+    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/core': 0.2.9
+    dev: true
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
     dev: true
 
   /tinyglobby@0.2.15:
@@ -3433,6 +5141,21 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+    dev: true
+
+  /tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    dev: true
+
+  /tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /tldts-core@7.0.16:
@@ -3469,6 +5192,10 @@ packages:
     engines: {node: '>=20'}
     dependencies:
       punycode: 2.3.1
+    dev: true
+
+  /trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
     dev: true
 
   /ts-api-utils@2.1.0(typescript@5.9.2):
@@ -3513,6 +5240,11 @@ packages:
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /typed-array-buffer@1.0.3:
@@ -3560,6 +5292,10 @@ packages:
       reflect.getprototypeof: 1.0.10
     dev: true
 
+  /typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+    dev: true
+
   /typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -3578,6 +5314,86 @@ packages:
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    dev: true
+
+  /unified-engine@11.2.2:
+    resolution: {integrity: sha512-15g/gWE7qQl9tQ3nAEbMd5h9HV1EACtFs6N9xaRBZICoCwnNGbal1kOs++ICf4aiTdItZxU2s/kYWhW7htlqJg==}
+    dependencies:
+      '@types/concat-stream': 2.0.3
+      '@types/debug': 4.1.12
+      '@types/is-empty': 1.2.3
+      '@types/node': 22.18.6
+      '@types/unist': 3.0.3
+      concat-stream: 2.0.0
+      debug: 4.4.3
+      extend: 3.0.2
+      glob: 10.4.5
+      ignore: 6.0.2
+      is-empty: 1.2.0
+      is-plain-obj: 4.1.0
+      load-plugin: 6.0.3
+      parse-json: 7.1.1
+      trough: 2.2.0
+      unist-util-inspect: 8.1.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+      vfile-reporter: 8.1.1
+      vfile-statistics: 3.0.0
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    dev: true
+
+  /unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+    dev: true
+
+  /unist-util-inspect@8.1.0:
+    resolution: {integrity: sha512-mOlg8Mp33pR0eeFpo5d2902ojqFFOKMMG2hF8bmH7ZlhnmjFgh0NI3/ZDwdaBJNbvrS7LZFVrBVtIE9KZ9s7vQ==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: true
+
+  /unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: true
+
+  /unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: true
+
+  /unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: true
+
+  /unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+    dev: true
+
+  /unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
     dev: true
 
   /unrs-resolver@1.11.1:
@@ -3613,11 +5429,203 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /uvu@0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.2.0
+      kleur: 4.1.5
+      sade: 1.8.1
+    dev: true
+
+  /validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+    dev: true
+
+  /validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
+  /vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+    dev: true
+
+  /vfile-reporter@8.1.1:
+    resolution: {integrity: sha512-qxRZcnFSQt6pWKn3PAk81yLK2rO2i7CDXpy8v8ZquiEOMLSnPw6BMSi9Y1sUCwGGl7a9b3CJT1CKpnRF7pp66g==}
+    dependencies:
+      '@types/supports-color': 8.1.3
+      string-width: 6.1.0
+      supports-color: 9.4.0
+      unist-util-stringify-position: 4.0.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+      vfile-sort: 4.0.0
+      vfile-statistics: 3.0.0
+    dev: true
+
+  /vfile-sort@4.0.0:
+    resolution: {integrity: sha512-lffPI1JrbHDTToJwcq0rl6rBmkjQmMuXkAxsZPRS9DXbaJQvc642eCg6EGxcX2i1L+esbuhq+2l9tBll5v8AeQ==}
+    dependencies:
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+    dev: true
+
+  /vfile-statistics@3.0.0:
+    resolution: {integrity: sha512-/qlwqwWBWFOmpXujL/20P+Iuydil0rZZNglR+VNm6J0gpLHwuVM5s7g2TfVoswbXjZ4HuIhLMySEyIw5i7/D8w==}
+    dependencies:
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+    dev: true
+
+  /vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+    dev: true
+
+  /vite-node@2.1.9(@types/node@22.18.6):
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.20(@types/node@22.18.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite@5.4.20(@types/node@22.18.6):
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 22.18.6
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.4
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@2.1.9(@types/node@22.18.6)(jsdom@27.0.0):
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 22.18.6
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.20)
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      jsdom: 27.0.0(postcss@8.4.31)
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20(@types/node@22.18.6)
+      vite-node: 2.1.9(@types/node@22.18.6)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
     dependencies:
       xml-name-validator: 5.0.0
+    dev: true
+
+  /walk-up-path@3.0.1:
+    resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
     dev: true
 
   /webidl-conversions@3.0.1:
@@ -3717,9 +5725,44 @@ packages:
       isexe: 2.0.0
     dev: true
 
+  /which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      isexe: 3.1.1
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
     dev: true
 
   /wrappy@1.0.2:
@@ -3748,7 +5791,17 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
+  /yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+    dev: true
+
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "types": ["vitest", "node"]
   },
   "include": [
     "**/*.mdx",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: false,
+    coverage: {
+      reporter: ["text", "json-summary"],
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,26 @@
+import React from "react";
+import { vi } from "vitest";
+
+type LinkProps = {
+  href: string | URL;
+  children: React.ReactNode;
+  className?: string;
+} & Record<string, unknown>;
+
+vi.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({ href, children, ...rest }: LinkProps) => {
+      const normalizedHref = typeof href === "string" ? href : href.toString();
+      return React.createElement("a", { href: normalizedHref, ...rest }, children);
+    },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));


### PR DESCRIPTION
## Summary
- configure eslint/typescript/mdx baseline and add prettier formatting defaults
- switch unit/component suites to vitest with jsdom setup for next components
- ensure curriculum route typings align with next build requirements

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #4.