### PR TITLE
docs: record sprint s1 implementation notes

### DIFF
--- a/docs/sprint/S1.md
+++ b/docs/sprint/S1.md
@@ -53,23 +53,32 @@ Produce a working static site shell that lists Integrated Math 3 units from sync
 - Chose Next.js `output: 'export'` with `trailingSlash: true` for GitHub Pages compatibility
 - All dynamic content must be generated at build-time or handled client-side
 - localStorage used for all user state (progress, settings, SRS data) to maintain static compatibility
+- Related work: Issue #1 · PR #7 captured the initial static shell implementation
 
 #### Content Loading Architecture
 - Build-time curriculum loading via `lib/getCurriculum()` transforms synced Khan Academy data
 - Type-safe curriculum schema with Zod validation prevents runtime errors
 - Curriculum overview page (`/curriculum`) renders static lesson listings that can be enhanced with client-side features
+- Related work: Issue #2 · PR #8 established the curriculum loader contracts
+
+#### Testing & Automation Baseline
+- Established `pnpm lint`, `pnpm test`, and `pnpm build` gates with Vitest + ESLint integration
+- Added initial loader unit tests and CI wiring to protect the static export pipeline
+- Documented curriculum sync via `pnpm` script with logging for reproducibility
+- Related work: Issue #4 · PR #12 (testing baseline) and Issue #5 · PR #13 (sync automation)
 
 #### Foundation for Future Features
 - **Mastery Tracking (Issue #9)**: The curriculum overview page structure established in Story #3 provides the foundation for adding visual mastery indicators (traffic light system). The static lesson listings can be enhanced with client-side `<MasteryIndicator />` components that read from localStorage progress data.
 - **Spaced Practice Integration**: localStorage schema established for progress tracking will extend naturally to support Leitner SRS scheduling
 - **Accessibility Framework**: Basic semantic markup and keyboard navigation patterns established in curriculum overview will scale to interactive components
+- Related work: Issue #3 · PR #11 (curriculum overview) and Issue #9 · PR #10 (mastery indicator prototype)
 
 ### Sprint S1 → S2 Handoff
 - Curriculum overview page ready for mastery indicator enhancement (Issue #9 prioritized for S2)
 - Progress tracking data structure designed but not yet implemented
 - Static export foundation proven compatible with client-side state management needs
 
-### Technical Debt & Follow-ups
-- Need to establish design token system for consistent colors (important for mastery indicators)
-- Consider performance optimization for large curriculum datasets in future sprints
-- Plan accessibility testing framework for interactive components coming in S2+
+### TODO & Future Work
+- Establish design token system for consistent color and typography usage (candidate follow-up issue for Sprint S2)
+- Investigate static build performance for large curriculum datasets and capture any caching strategies needed
+- Stand up automated accessibility testing (axe/Playwright) ahead of interactive component work in S2+


### PR DESCRIPTION
## Summary
- document sprint S1 architectural decisions with issue references
- add testing and automation baseline context
- capture TODO & future work list for handoff into sprint S2

## Testing
- not run

Closes #6.